### PR TITLE
Added Null Directory Check

### DIFF
--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -101,15 +101,16 @@ function FindLatestPythonExecutableInRegistry {
     $PythonCoreRegistryLocation = "${RootRegistryLocation}:\Software\Python\PythonCore"
     if (Test-Path $PythonCoreRegistryLocation) {
         LogOutput "Python found in registry: $PythonCoreRegistryLocation"
-
         $PythonInstallations = (Get-ChildItem -recurse $PythonCoreRegistryLocation) | Sort-Object -Descending
-        ForEach ($Installation in $PythonInstallations) {
-            # we are sorting by descending so this will grab the greatest installed version of python
-            If ($installation.Name.EndsWith("\InstallPath")) {
-                $PythonInstallLocation = (Get-ItemProperty -LiteralPath $Installation.PSPath).'(default)'
-                return Join-Path $PythonInstallLocation "python.exe"
-            }
-        }
+        if ($PythonInstallations) {
+           ForEach ($Installation in $PythonInstallations) {
+               # we are sorting by descending so this will grab the greatest installed version of python
+               If ($installation.Name.EndsWith("\InstallPath")) {
+                   $PythonInstallLocation = (Get-ItemProperty -LiteralPath $Installation.PSPath).'(default)'
+                   return Join-Path $PythonInstallLocation "python.exe"
+               }
+           }
+        }  
     }
 
     return $PythonExecutable


### PR DESCRIPTION
 FindLatestPythonExecutableInRegistry - Added Null Directory Check to ignore registry key that exists, but is null.

Validation Test is here: 
![oci-fix](https://user-images.githubusercontent.com/120213/36440644-0c4802c0-163e-11e8-9788-da242891df84.gif)
