### PR TITLE
Fix install script infinite loop

### DIFF
--- a/scripts/install/install.py
+++ b/scripts/install/install.py
@@ -178,7 +178,7 @@ def get_install_dir():
             create_dir(install_dir)
             if os.listdir(install_dir):
                 print_status("'{}' is not empty and may contain a previous installation.".format(install_dir))
-                ans_yes = prompt_y_n('Remove this directory?', 'n')
+                ans_yes = True if ACCEPT_ALL_DEFAULTS else prompt_y_n('Remove this directory?', 'n')
                 if ans_yes:
                     try:
                         shutil.rmtree(install_dir)

--- a/scripts/install/install.py
+++ b/scripts/install/install.py
@@ -177,8 +177,12 @@ def get_install_dir():
         else:
             create_dir(install_dir)
             if os.listdir(install_dir):
-                print_status("'{}' is not empty and may contain a previous installation.".format(install_dir))
-                ans_yes = True if ACCEPT_ALL_DEFAULTS else prompt_y_n('Remove this directory?', 'n')
+                print_status("Install directory '{}' is not empty and may contain a previous installation.".format(install_dir))
+                if ACCEPT_ALL_DEFAULTS:
+                    # default behavior is to NOT delete an existing directory and re-prompt for install_dir, but we can't re-prompt if ACCEPT_ALL_DEFAULTS is set
+                    sys.exit("Refusing to remove existing directory {}. Please remove directory manually and re-run installation script.".format(install_dir))
+
+                ans_yes = prompt_y_n('Remove this directory?', 'n')
                 if ans_yes:
                     try:
                         shutil.rmtree(install_dir)


### PR DESCRIPTION
This PR fixes an infinite loop in the install script when an existing installation is present and the script is run with --accept-all-defaults.  The new behavior is that the script will exit and inform the user to remove the existing installation manually if they want to continue.  This is consistent with the default behavior for the script when running interactively (without --accept-all-defaults).