### PR TITLE
Bump python-dateutil to new version to resolve issue parsing the date from server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ pycparser==2.17
 pyOpenSSL==17.4.0
 pyparsing==2.2.0
 pytest==3.2.3
-python-dateutil==2.5.3
+python-dateutil==2.7.3
 pytz==2016.10
 requests==2.18.4
 retrying==1.3.3

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ requires = [
     'pyOpenSSL<=17.4.0',
     'httpsig_cffi==15.0.0',
     'jmespath==0.9.3',
-    'python-dateutil==2.5.3',
+    'python-dateutil==2.7.3',
     'pytz==2016.10',
     'retrying==1.3.3',
     'requests[security]==2.18.4',


### PR DESCRIPTION
When I make requests using the CLI on my mac using python 3.6.5 I get a warning about mismatched time with the server.
It looks like it's interpretting the server's date header in the local system timezone (even though the header contains `GMT`)

Bumping `python-dateutil` to version 2.7.3 seems to have resolved this for me.