### PR TITLE
Releasing version 2.4.39

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`__.
 
+2.4.39 - 2018-11-29
+-------------------
+Added
+~~~~~
+* Support for fetching bucket statistics in Object Storage getBucket service.
+  * (``oci os bucket get --bucket-name --namespace-name --fields``)
+  * An example on using the feature can be found on `GitHub <https://github.com/oracle/oci-cli/blob/master/scripts/examples/get_bucket_example.sh>`__
+
 2.4.38 - 2018-11-15
 -------------------
 Added

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 Copyright (c) 2016, 2018, Oracle and/or its affiliates.  All rights reserved.
 
-This software is dual-licensed to you under the Universal Permissive License (UPL) and Apache License 2.0.  See below for license terms.  You may choose either license, or both.
+This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 or Apache License 2.0.  See below for license terms.  You may choose either license.
  ____________________________
 The Universal Permissive License (UPL), Version 1.0
 Copyright (c) 2016, 2018, Oracle and/or its affiliates.  All rights reserved.

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ Jinja2==2.9.6
 jmespath==0.9.3
 ndg-httpsclient==0.4.2
 mock==2.0.0
-oci==2.1.1
+oci==2.1.2
 packaging==16.8
 pluggy==0.4.0
 py==1.4.33

--- a/scripts/examples/get_bucket_example.sh
+++ b/scripts/examples/get_bucket_example.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+# This script provides an example of how to get bucket in object storage.
+#
+# Requirements for running this script:
+#   - OCI CLI v2.4.33 or later (you can check this by running oci --version)
+#   - jq (https://stedolan.github.io/jq/) for JSON querying and manipulation of CLI output. This may be a useful utility in general
+#     and may help cater to scenarios which can't be wholly addressed by the --query option in the CLI
+set -e
+
+#This field needs to be set
+BUCKET_NAME=""
+
+echo "Fetching namespace."
+NAMESPACE=$(oci os ns get | jq -r .data)
+echo "Using namespace '$NAMESPACE'."
+
+#Fetching bucket information and approximate number of objects in it 
+DATA1=$(oci os bucket get --bucket-name $BUCKET_NAME --namespace-name  $NAMESPACE --fields 'approximateCount' | jq -r .data)
+
+echo "Bucket Details : '$DATA1'"
+
+#Fetching bucket information and its approximate Size 
+DATA2=$(oci os bucket get --bucket-name $BUCKET_NAME --namespace-name  $NAMESPACE --fields 'approximateSize' | jq -r .data)
+
+echo "Bucket Details : '$DATA2'"
+
+#Fetching bucket information and its approximate Size and approximate count of objects in it
+DATA3=$(oci os bucket get --bucket-name $BUCKET_NAME --namespace-name  $NAMESPACE --fields 'approximateSize' --fields 'approximateCount' | jq -r .data)
+
+echo "Bucket Details : '$DATA3'"

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open_relative("README.rst") as f:
     readme = f.read()
 
 requires = [
-    'oci==2.1.1',
+    'oci==2.1.2',
     'arrow==0.10.0',
     'certifi',
     'click==6.7',

--- a/src/oci_cli/generated/objectstorage_cli.py
+++ b/src/oci_cli/generated/objectstorage_cli.py
@@ -542,12 +542,13 @@ def delete_preauthenticated_request(ctx, from_json, namespace_name, bucket_name,
 @cli_util.option('--bucket-name', required=True, help="""The name of the bucket. Avoid entering confidential information. Example: `my-new-bucket1`""")
 @cli_util.option('--if-match', help="""The entity tag to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object. For uploading a part, this is the entity tag of the target part.""")
 @cli_util.option('--if-none-match', help="""The entity tag to avoid matching. The only valid value is '*', which indicates that the request should fail if the object already exists. For creating and committing a multipart upload, this is the entity tag of the target object. For uploading a part, this is the entity tag of the target part.""")
+@cli_util.option('--fields', type=custom_types.CliCaseInsensitiveChoice(["approximateCount", "approximateSize"]), multiple=True, help="""Bucket summary includes the 'namespace', 'name', 'compartmentId', 'createdBy', 'timeCreated', and 'etag' fields. This parameter can also include 'approximateCount' (Approximate number of objects) and 'approximateSize' (total approximate size in bytes of all objects). For example 'approximateCount,approximateSize'""")
 @json_skeleton_utils.get_cli_json_input_option({})
 @cli_util.help_option
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={}, output_type={'module': 'object_storage', 'class': 'Bucket'})
 @cli_util.wrap_exceptions
-def get_bucket(ctx, from_json, namespace_name, bucket_name, if_match, if_none_match):
+def get_bucket(ctx, from_json, namespace_name, bucket_name, if_match, if_none_match, fields):
 
     if isinstance(namespace_name, six.string_types) and len(namespace_name.strip()) == 0:
         raise click.UsageError('Parameter --namespace-name cannot be whitespace or empty string')
@@ -559,6 +560,8 @@ def get_bucket(ctx, from_json, namespace_name, bucket_name, if_match, if_none_ma
         kwargs['if_match'] = if_match
     if if_none_match is not None:
         kwargs['if_none_match'] = if_none_match
+    if fields is not None and len(fields) > 0:
+        kwargs['fields'] = fields
     kwargs['opc_client_request_id'] = cli_util.use_or_generate_request_id(ctx.obj['request_id'])
     client = cli_util.build_client('object_storage', ctx)
     result = client.get_bucket(

--- a/src/oci_cli/version.py
+++ b/src/oci_cli/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = '2.4.38'
+__version__ = '2.4.39'

--- a/tests/output/inline-help/os.txt
+++ b/tests/output/inline-help/os.txt
@@ -214,6 +214,15 @@ Options:
                                   multipart upload, this is the entity tag of
                                   the target object. For uploading a part, this
                                   is the entity tag of the target part.
+  --fields [approximateCount|approximateSize]
+                                  Bucket summary includes the 'namespace',
+                                  'name', 'compartmentId', 'createdBy',
+                                  'timeCreated', and 'etag' fields. This
+                                  parameter can also include 'approximateCount'
+                                  (Approximate number of objects) and
+                                  'approximateSize' (total approximate size in
+                                  bytes of all objects). For example
+                                  'approximateCount,approximateSize'
   --from-json TEXT                Provide input to this command as a JSON
                                   document from a file.
                                   


### PR DESCRIPTION
## 2.4.39 - 2018-11-29
### Added
- Support for fetching bucket statistics in Object Storage getBucket service. * (oci os bucket get --bucket-name --namespace-name --fields) * An example on using the feature can be found on GitHub
