### PR TITLE
Install script -- create bashrc file if it does not exist

### DIFF
--- a/scripts/install/install.py
+++ b/scripts/install/install.py
@@ -314,9 +314,7 @@ def get_rc_file_path():
     rc_file = rc_file or prompt_input_with_default('Enter a path to an rc file to update', default_rc_file)
     if rc_file:
         rc_file_path = os.path.realpath(os.path.expanduser(rc_file))
-        if os.path.isfile(rc_file_path):
-            return rc_file_path
-        print_status("The file '{}' could not be found.".format(rc_file_path))
+        return rc_file_path
     return None
 
 


### PR DESCRIPTION
Not sure if there's another requirement that motivates this check, but in my case I wanted the path added to an rc file that did not exist at the time. It is more convenient in that case if the file is created. Deleting the check does not appear (at a glance) to invalidate any of the followup functionality, as file-no-exist errors are already handled.