### PR TITLE
Fix recognition of '~' in cert-bundle on OS X

### DIFF
--- a/src/oci_cli/cli_util.py
+++ b/src/oci_cli/cli_util.py
@@ -276,7 +276,7 @@ def build_client(service_name, ctx):
                 raise click.BadParameter(param_hint='cert_bundle', message='Cannot find cert_bundle file: {}'.format(cert_bundle))
 
             # TODO: Update this once alternate certs are exposed in the SDK.
-            client.base_client.session.verify = ctx.obj['cert_bundle']
+            client.base_client.session.verify = cert_bundle
 
         return client
     except exceptions.InvalidPrivateKey as bad_key:


### PR DESCRIPTION
Example error message:
```
> oci compute shape list --profile MYTENANCY
OSError: Could not find a suitable TLS CA certificate bundle, invalid path: ~/.oci/cert-bundle.crt
```
With `oci_cli_rc` config:
```
[MYTENANCY]
cert-bundle=~/.oci/cert-bundle.crt
compartment-id=<MYCOMPARTMENT>
availability-domain=<MYAD>
subnet-id=<MYSUBNET>
```

This failure required a workaround of hard coding the home directory, causing failures if a config file is shared between operating systems.

The code now uses the local variable `cert_bundle`, which is the same value that was expanded and checked in the lines directly above. This is more natural and also resolves the issue.

The TODO also appears to be obsolete, though I don't know if "Update this" has already been done.