### PR TITLE
Releasing version 2.6.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,39 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`__.
 
+2.6.6 - 2019-09-24
+-------------------
+Added
+~~~~~
+* ``--verify-checksum`` option for the following commands: ``oci os object put`` and ``oci os object bulk-upload``. This option will print a message indicating whether the checksum for the uploaded file matches the local file. Sample message: 'md5 checksum matches [Local: AikPDj8xbhaUNKeS956p1A==]'
+
+* Support for re-encrypting a bucket.
+
+  * ``oci os bucket reencrypt --namespace-name --bucket-name``
+
+* Support for enabling/disabling bucket level events.
+
+  * ``oci os bucket create --object-events-enabled``
+  * ``oci os bucket update --object-events-enabled``
+
+* Improve Autonomous Database to change the whitelist ips feature.
+
+  * ``oci db autonomous-database update --whitelisted-ips``
+
+* Support for Autonomous Database to create with the whitelist ips feature.
+
+  * ``oci db autonomous-database create --whitelisted-ips``
+
+Changed
+~~~~~~~
+* Default CreateKubeconfig so it uses token version 2.0.0
+
+  * ``oci ce cluster create-kubeconfig``
+
+Fixed
+~~~~~
+* ``oci session authenticate`` was not correctly redirecting to the correct URL for government regions
+
 2.6.5 - 2019-09-17
 -------------------
 Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ Jinja2==2.10.1
 jmespath==0.9.3
 ndg-httpsclient==0.4.2
 mock==2.0.0
-oci==2.5.0
+oci==2.5.1
 packaging==16.8
 pluggy==0.4.0
 py==1.4.33

--- a/services/container_engine/docs/inline-help/ce.txt
+++ b/services/container_engine/docs/inline-help/ce.txt
@@ -148,44 +148,48 @@ Usage: oci ce cluster create-kubeconfig [OPTIONS]
   Create the Kubeconfig YAML for a cluster.
 
 Options:
-  --cluster-id TEXT     The OCID of the cluster. [required]
-  --token-version TEXT  The version of the kubeconfig token. Supported values
-                        1.0.0 and 2.0.0
-  --expiration INTEGER  The desired expiration, in seconds, to use for the
-                        kubeconfig token. Important Note, expiration field is
-                        only honored for token version 1.0.0
-  --file PATH           The name of the file that will be updated with response
-                        data, or '-' to write to STDOUT. [default:
-                        ~/.kube/config]
-  --overwrite           Overwrites the contents of kubeconfig file specified
-                        using --file option or kubeconfig file at default
-                        location if --file is not used.
-  --from-json TEXT      Provide input to this command as a JSON document from a
-                        file using the file://path-to/file syntax.
-                        
-                        The
-                        --generate-full-command-json-input option can be used to
-                        generate a sample json file to be used with this command
-                        option. The key names are pre-populated and match the
-                        command option names (converted to camelCase format,
-                        e.g. compartment-id --> compartmentId), while the values
-                        of the keys need to be populated by the user before
-                        using the sample file as an input to this command. For
-                        any command option that accepts multiple values, the
-                        value of the key can be a JSON array.
-                        
-                        Options can still
-                        be provided on the command line. If an option exists in
-                        both the JSON document and the command line then the
-                        command line specified value will be used.
-                        
-                        For examples
-                        on usage of this option, please see our "using CLI with
-                        advanced JSON options" link: https://docs.cloud.oracle.c
-                        om/iaas/Content/API/SDKDocs/cliusing.htm#AdvancedJSONOpt
-                        ions
-  -?, -h, --help        For detailed help on any of these individual commands,
-                        enter <command> --help.
+  --cluster-id TEXT              The OCID of the cluster. [required]
+  --expiration INTEGER           The desired expiration, in seconds, to use for
+                                 the kubeconfig token. Important Note,
+                                 expiration field is only honored for token
+                                 version 1.0.0
+  --file PATH                    The name of the file that will be updated with
+                                 response data, or '-' to write to STDOUT.
+                                 [default: ~/.kube/config]
+  --token-version [1.0.0|2.0.0]  The version of the kubeconfig token. Supported
+                                 values 1.0.0 and 2.0.0
+  --overwrite                    Overwrites the contents of kubeconfig file
+                                 specified using --file option or kubeconfig
+                                 file at default location if --file is not used.
+  --from-json TEXT               Provide input to this command as a JSON
+                                 document from a file using the file://path-
+                                 to/file syntax.
+                                 
+                                 The --generate-full-command-
+                                 json-input option can be used to generate a
+                                 sample json file to be used with this command
+                                 option. The key names are pre-populated and
+                                 match the command option names (converted to
+                                 camelCase format, e.g. compartment-id -->
+                                 compartmentId), while the values of the keys
+                                 need to be populated by the user before using
+                                 the sample file as an input to this command.
+                                 For any command option that accepts multiple
+                                 values, the value of the key can be a JSON
+                                 array.
+                                 
+                                 Options can still be provided on the
+                                 command line. If an option exists in both the
+                                 JSON document and the command line then the
+                                 command line specified value will be used.
+                                 
+                                 For
+                                 examples on usage of this option, please see
+                                 our "using CLI with advanced JSON options"
+                                 link: https://docs.cloud.oracle.com/iaas/Conten
+                                 t/API/SDKDocs/cliusing.htm#AdvancedJSONOptions
+  -?, -h, --help                 For detailed help on any of these individual
+                                 commands, enter <command> --help.
 
 ++++++++++++++++++++++++++++++++++++++++++++++
 $ oci ce cluster delete --help

--- a/services/container_engine/src/oci_cli_container_engine/containerengine_cli_extended.py
+++ b/services/container_engine/src/oci_cli_container_engine/containerengine_cli_extended.py
@@ -210,11 +210,12 @@ def update_node_pool(ctx, **kwargs):
 # new one, if it does not exist.
 # 3. Running CLI command to obtain new kubeconfig always sets the default context to the new cluster.
 # 4. A ‘merged’ kubeconfig file does not have any duplicates and the information is not lost or corrupted in any way.
-@cli_util.copy_params_from_generated_command(containerengine_cli.create_kubeconfig, params_to_exclude=['file'])
+@cli_util.copy_params_from_generated_command(containerengine_cli.create_kubeconfig, params_to_exclude=['file', 'token_version'])
 @containerengine_cli.cluster_group.command(name=cli_util.override('create_kubeconfig.command_name', 'create-kubeconfig'),
                                            help="""Create the Kubeconfig YAML for a cluster.""")
 @cli_util.option('--file', type=click.Path(), default=DEFAULT_KUBECONFIG_LOCATION, show_default=True,
                  help="The name of the file that will be updated with response data, or '-' to write to STDOUT.")
+@cli_util.option('--token-version', default="2.0.0", help=u"""The version of the kubeconfig token. Supported values 1.0.0 and 2.0.0""", type=custom_types.CliCaseInsensitiveChoice(['1.0.0', '2.0.0']))
 @cli_util.option('--overwrite', is_flag=True, help="""Overwrites the contents of kubeconfig file specified using --file\
  option or kubeconfig file at default location if --file is not used.""")
 @click.pass_context

--- a/services/container_engine/tests/integ/test_containerengine.py
+++ b/services/container_engine/tests/integ/test_containerengine.py
@@ -407,12 +407,6 @@ def test_create_kubeconfig_2(runner, config_file, config_profile, oce_cluster, r
         assert(len(kubeconfig['clusters']) == len(kubeconfig2['clusters']))
         assert(len(kubeconfig['contexts']) == len(kubeconfig2['contexts']))
         assert(len(kubeconfig['users']) == len(kubeconfig2['users']))
-        # Check the token value has changed within the users for one of the clusters
-        token_changed_count = 0
-        for idx, _ in enumerate(kubeconfig['users']):
-            if kubeconfig['users'][idx]['user']['token'] != kubeconfig2['users'][idx]['user']['token']:
-                token_changed_count += 1
-        assert(token_changed_count == 1)
 
 
 # INPUT:

--- a/services/monitoring/docs/inline-help/monitoring.txt
+++ b/services/monitoring/docs/inline-help/monitoring.txt
@@ -185,28 +185,28 @@ Options:
                                   windows for the alarm. Supported value: `1m`
   --pending-duration TEXT         The period of time that the condition defined
                                   in the alarm must persist before the alarm
-                                  state changes from "OK" to "FIRING" or vice
-                                  versa. For example, a value of 5 minutes means
-                                  that the alarm must persist in breaching the
-                                  condition for five minutes before the alarm
-                                  updates its state to "FIRING"; likewise, the
-                                  alarm must persist in not breaching the
-                                  condition for five minutes before the alarm
-                                  updates its state to "OK."
+                                  state changes from "OK" to "FIRING". For
+                                  example, a value of 5 minutes means that the
+                                  alarm must persist in breaching the condition
+                                  for five minutes before the alarm updates its
+                                  state to "FIRING".
                                   
-                                  The duration is
-                                  specified as a string in ISO 8601 format
-                                  (`PT10M` for ten minutes or `PT1H` for one
-                                  hour). Minimum: PT1M. Maximum: PT1H. Default:
-                                  PT1M.
+                                  The duration is specified
+                                  as a string in ISO 8601 format (`PT10M` for
+                                  ten minutes or `PT1H` for one hour). Minimum:
+                                  PT1M. Maximum: PT1H. Default: PT1M.
                                   
-                                  Under the default value of PT1M, the
-                                  first evaluation that breaches the alarm
-                                  updates the state to "FIRING" and the first
-                                  evaluation that does not breach the alarm
-                                  updates the state to "OK".
+                                  Under the
+                                  default value of PT1M, the first evaluation
+                                  that breaches the alarm updates the state to
+                                  "FIRING".
                                   
-                                  Example: `PT5M`
+                                  The alarm updates its status to
+                                  "OK" when the breaching condition has been
+                                  clear for the most recent minute.
+                                  
+                                  Example:
+                                  `PT5M`
   --body TEXT                     The human-readable content of the notification
                                   delivered. Oracle recommends providing
                                   guidance to operators for resolving the alarm
@@ -313,21 +313,20 @@ Options:
                                   
                                   Example of threshold alarm:
                                   -----
-                                  
-                                      CpuUtilization[1m]{availabilityDoma
-                                  in="cumS:PHX-AD-1"}.groupBy(availabilityDomain
-                                  ).percentile(0.9) > 85
-                                  
-                                    -----
-                                  
-                                  Example of
-                                  absence alarm:
+                                  CpuUtilization[1m]{availabilityDomain="cumS
+                                  :PHX-AD-1"}.groupBy(availabilityDomain).percen
+                                  tile(0.9) > 85
                                   
                                     -----
                                   
-                                      CpuUtilization[1m
-                                  ]{availabilityDomain="cumS:PHX-AD-1"}.absent()
-                                  ----- [required]
+                                  Example of absence
+                                  alarm:
+                                  
+                                    -----
+                                  CpuUtilization[1m]{availabilityDomain="cumS
+                                  :PHX-AD-1"}.absent()
+                                  
+                                    ----- [required]
   --from-json TEXT                Provide input to this command as a JSON
                                   document from a file using the file://path-
                                   to/file syntax.
@@ -364,7 +363,10 @@ Usage: oci monitoring alarm delete [OPTIONS]
   Deletes the specified alarm. For important limits information, see [Limits
   on Monitoring].
 
-  Transactions Per Second (TPS) per-tenancy limit for this operation: 1.
+  This call is subject to a Monitoring limit that applies to the total number
+  of requests across all alarm operations. Monitoring might throttle this call
+  to reject an otherwise valid request when the total rate of alarm operations
+  exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.
 
 Options:
   --alarm-id TEXT                 The [OCID] of an alarm. [required]
@@ -429,7 +431,10 @@ Usage: oci monitoring alarm get [OPTIONS]
   Gets the specified alarm. For important limits information, see [Limits on
   Monitoring].
 
-  Transactions Per Second (TPS) per-tenancy limit for this operation: 1.
+  This call is subject to a Monitoring limit that applies to the total number
+  of requests across all alarm operations. Monitoring might throttle this call
+  to reject an otherwise valid request when the total rate of alarm operations
+  exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.
 
 Options:
   --alarm-id TEXT   The [OCID] of an alarm. [required]
@@ -464,7 +469,10 @@ Usage: oci monitoring alarm list [OPTIONS]
   Lists the alarms for the specified compartment. For important limits
   information, see [Limits on Monitoring].
 
-  Transactions Per Second (TPS) per-tenancy limit for this operation: 1.
+  This call is subject to a Monitoring limit that applies to the total number
+  of requests across all alarm operations. Monitoring might throttle this call
+  to reject an otherwise valid request when the total rate of alarm operations
+  exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.
 
 Options:
   -c, --compartment-id TEXT       The [OCID] of the compartment containing the
@@ -608,28 +616,28 @@ Options:
                                   windows for the alarm. Supported value: `1m`
   --pending-duration TEXT         The period of time that the condition defined
                                   in the alarm must persist before the alarm
-                                  state changes from "OK" to "FIRING" or vice
-                                  versa. For example, a value of 5 minutes means
-                                  that the alarm must persist in breaching the
-                                  condition for five minutes before the alarm
-                                  updates its state to "FIRING"; likewise, the
-                                  alarm must persist in not breaching the
-                                  condition for five minutes before the alarm
-                                  updates its state to "OK."
+                                  state changes from "OK" to "FIRING". For
+                                  example, a value of 5 minutes means that the
+                                  alarm must persist in breaching the condition
+                                  for five minutes before the alarm updates its
+                                  state to "FIRING".
                                   
-                                  The duration is
-                                  specified as a string in ISO 8601 format
-                                  (`PT10M` for ten minutes or `PT1H` for one
-                                  hour). Minimum: PT1M. Maximum: PT1H. Default:
-                                  PT1M.
+                                  The duration is specified
+                                  as a string in ISO 8601 format (`PT10M` for
+                                  ten minutes or `PT1H` for one hour). Minimum:
+                                  PT1M. Maximum: PT1H. Default: PT1M.
                                   
-                                  Under the default value of PT1M, the
-                                  first evaluation that breaches the alarm
-                                  updates the state to "FIRING" and the first
-                                  evaluation that does not breach the alarm
-                                  updates the state to "OK".
+                                  Under the
+                                  default value of PT1M, the first evaluation
+                                  that breaches the alarm updates the state to
+                                  "FIRING".
                                   
-                                  Example: `PT5M`
+                                  The alarm updates its status to
+                                  "OK" when the breaching condition has been
+                                  clear for the most recent minute.
+                                  
+                                  Example:
+                                  `PT5M`
   --severity TEXT                 The perceived severity of the alarm with
                                   regard to the affected system.
                                   
@@ -776,21 +784,20 @@ Options:
                                   
                                   Example of threshold alarm:
                                   -----
-                                  
-                                      CpuUtilization[1m]{availabilityDoma
-                                  in="cumS:PHX-AD-1"}.groupBy(availabilityDomain
-                                  ).percentile(0.9) > 85
-                                  
-                                    -----
-                                  
-                                  Example of
-                                  absence alarm:
+                                  CpuUtilization[1m]{availabilityDomain="cumS
+                                  :PHX-AD-1"}.groupBy(availabilityDomain).percen
+                                  tile(0.9) > 85
                                   
                                     -----
                                   
-                                      CpuUtilization[1m
-                                  ]{availabilityDomain="cumS:PHX-AD-1"}.absent()
-                                  -----
+                                  Example of absence
+                                  alarm:
+                                  
+                                    -----
+                                  CpuUtilization[1m]{availabilityDomain="cumS
+                                  :PHX-AD-1"}.absent()
+                                  
+                                    -----
   --from-json TEXT                Provide input to this command as a JSON
                                   document from a file using the file://path-
                                   to/file syntax.
@@ -841,7 +848,10 @@ Usage: oci monitoring alarm-history-collection get-alarm-history
   Get the history of the specified alarm. For important limits information,
   see [Limits on Monitoring].
 
-  Transactions Per Second (TPS) per-tenancy limit for this operation: 1.
+  This call is subject to a Monitoring limit that applies to the total number
+  of requests across all alarm operations. Monitoring might throttle this call
+  to reject an otherwise valid request when the total rate of alarm operations
+  exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.
 
 Options:
   --alarm-id TEXT                 The [OCID] of an alarm. [required]
@@ -1077,7 +1087,10 @@ Usage: oci monitoring alarm-status list-alarms-status [OPTIONS]
   List the status of each alarm in the specified compartment. For important
   limits information, see [Limits on Monitoring].
 
-  Transactions Per Second (TPS) per-tenancy limit for this operation: 1.
+  This call is subject to a Monitoring limit that applies to the total number
+  of requests across all alarm operations. Monitoring might throttle this call
+  to reject an otherwise valid request when the total rate of alarm operations
+  exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.
 
 Options:
   -c, --compartment-id TEXT       The [OCID] of the compartment containing the
@@ -1185,7 +1198,7 @@ Usage: oci monitoring metric list [OPTIONS]
   Compartment OCID required. For information about metrics, see [Metrics
   Overview]. For important limits information, see [Limits on Monitoring].
 
-  Transactions Per Second (TPS) per-tenancy limit for this operation: 1.
+  Transactions Per Second (TPS) per-tenancy limit for this operation: 10.
 
 Options:
   -c, --compartment-id TEXT       The [OCID] of the compartment containing the
@@ -1725,7 +1738,10 @@ Usage: oci monitoring suppression remove [OPTIONS]
   Removes any existing suppression for the specified alarm. For important
   limits information, see [Limits on Monitoring].
 
-  Transactions Per Second (TPS) per-tenancy limit for this operation: 1.
+  This call is subject to a Monitoring limit that applies to the total number
+  of requests across all alarm operations. Monitoring might throttle this call
+  to reject an otherwise valid request when the total rate of alarm operations
+  exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.
 
 Options:
   --alarm-id TEXT   The [OCID] of an alarm. [required]

--- a/services/monitoring/src/oci_cli_monitoring/generated/monitoring_cli.py
+++ b/services/monitoring/src/oci_cli_monitoring/generated/monitoring_cli.py
@@ -118,7 +118,7 @@ def change_alarm_compartment(ctx, from_json, alarm_id, compartment_id, if_match)
 
 @alarm_group.command(name=cli_util.override('create_alarm.command_name', 'create'), help=u"""Creates a new alarm in the specified compartment. For important limits information, see [Limits on Monitoring].
 
-Transactions Per Second (TPS) per-tenancy limit for this operation: 1.""")
+This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations. Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.""")
 @cli_util.option('--display-name', required=True, help=u"""A user-friendly name for the alarm. It does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 This name is sent as the title for notifications related to this alarm.
@@ -160,11 +160,13 @@ Example: `true`""")
 
 Example: `frontend-fleet`""")
 @cli_util.option('--resolution', help=u"""The time between calculated aggregation windows for the alarm. Supported value: `1m`""")
-@cli_util.option('--pending-duration', help=u"""The period of time that the condition defined in the alarm must persist before the alarm state changes from \"OK\" to \"FIRING\" or vice versa. For example, a value of 5 minutes means that the alarm must persist in breaching the condition for five minutes before the alarm updates its state to \"FIRING\"; likewise, the alarm must persist in not breaching the condition for five minutes before the alarm updates its state to \"OK.\"
+@cli_util.option('--pending-duration', help=u"""The period of time that the condition defined in the alarm must persist before the alarm state changes from \"OK\" to \"FIRING\". For example, a value of 5 minutes means that the alarm must persist in breaching the condition for five minutes before the alarm updates its state to \"FIRING\".
 
 The duration is specified as a string in ISO 8601 format (`PT10M` for ten minutes or `PT1H` for one hour). Minimum: PT1M. Maximum: PT1H. Default: PT1M.
 
-Under the default value of PT1M, the first evaluation that breaches the alarm updates the state to \"FIRING\" and the first evaluation that does not breach the alarm updates the state to \"OK\".
+Under the default value of PT1M, the first evaluation that breaches the alarm updates the state to \"FIRING\".
+
+The alarm updates its status to \"OK\" when the breaching condition has been clear for the most recent minute.
 
 Example: `PT5M`""")
 @cli_util.option('--body', help=u"""The human-readable content of the notification delivered. Oracle recommends providing guidance to operators for resolving the alarm condition. Consider adding links to standard runbook practices. Avoid entering confidential information.
@@ -260,7 +262,7 @@ def create_alarm(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval
 
 @alarm_group.command(name=cli_util.override('delete_alarm.command_name', 'delete'), help=u"""Deletes the specified alarm. For important limits information, see [Limits on Monitoring].
 
-Transactions Per Second (TPS) per-tenancy limit for this operation: 1.""")
+This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations. Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.""")
 @cli_util.option('--alarm-id', required=True, help=u"""The [OCID] of an alarm.""")
 @cli_util.option('--if-match', help=u"""For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource.  The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.""")
 @cli_util.confirm_delete_option
@@ -325,7 +327,7 @@ def delete_alarm(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval
 
 @alarm_group.command(name=cli_util.override('get_alarm.command_name', 'get'), help=u"""Gets the specified alarm. For important limits information, see [Limits on Monitoring].
 
-Transactions Per Second (TPS) per-tenancy limit for this operation: 1.""")
+This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations. Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.""")
 @cli_util.option('--alarm-id', required=True, help=u"""The [OCID] of an alarm.""")
 @json_skeleton_utils.get_cli_json_input_option({})
 @cli_util.help_option
@@ -349,7 +351,7 @@ def get_alarm(ctx, from_json, alarm_id):
 
 @alarm_history_collection_group.command(name=cli_util.override('get_alarm_history.command_name', 'get-alarm-history'), help=u"""Get the history of the specified alarm. For important limits information, see [Limits on Monitoring].
 
-Transactions Per Second (TPS) per-tenancy limit for this operation: 1.""")
+This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations. Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.""")
 @cli_util.option('--alarm-id', required=True, help=u"""The [OCID] of an alarm.""")
 @cli_util.option('--alarm-historytype', type=custom_types.CliCaseInsensitiveChoice(["STATE_HISTORY", "STATE_TRANSITION_HISTORY"]), help=u"""The type of history entries to retrieve. State history (STATE_HISTORY) or state transition history (STATE_TRANSITION_HISTORY). If not specified, entries of both types are retrieved.
 
@@ -398,7 +400,7 @@ def get_alarm_history(ctx, from_json, alarm_id, alarm_historytype, page, limit, 
 
 @alarm_group.command(name=cli_util.override('list_alarms.command_name', 'list'), help=u"""Lists the alarms for the specified compartment. For important limits information, see [Limits on Monitoring].
 
-Transactions Per Second (TPS) per-tenancy limit for this operation: 1.""")
+This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations. Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.""")
 @cli_util.option('--compartment-id', required=True, help=u"""The [OCID] of the compartment containing the resources monitored by the metric that you are searching for. Use tenancyId to search in the root compartment.
 
 Example: `ocid1.compartment.oc1..exampleuniqueID`""")
@@ -473,7 +475,7 @@ def list_alarms(ctx, from_json, all_pages, page_size, compartment_id, page, limi
 
 @alarm_status_group.command(name=cli_util.override('list_alarms_status.command_name', 'list-alarms-status'), help=u"""List the status of each alarm in the specified compartment. For important limits information, see [Limits on Monitoring].
 
-Transactions Per Second (TPS) per-tenancy limit for this operation: 1.""")
+This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations. Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.""")
 @cli_util.option('--compartment-id', required=True, help=u"""The [OCID] of the compartment containing the resources monitored by the metric that you are searching for. Use tenancyId to search in the root compartment.
 
 Example: `ocid1.compartment.oc1..exampleuniqueID`""")
@@ -545,7 +547,7 @@ def list_alarms_status(ctx, from_json, all_pages, page_size, compartment_id, com
 
 @metric_group.command(name=cli_util.override('list_metrics.command_name', 'list'), help=u"""Returns metric definitions that match the criteria specified in the request. Compartment OCID required. For information about metrics, see [Metrics Overview]. For important limits information, see [Limits on Monitoring].
 
-Transactions Per Second (TPS) per-tenancy limit for this operation: 1.""")
+Transactions Per Second (TPS) per-tenancy limit for this operation: 10.""")
 @cli_util.option('--compartment-id', required=True, help=u"""The [OCID] of the compartment containing the resources monitored by the metric that you are searching for. Use tenancyId to search in the root compartment.
 
 Example: `ocid1.compartment.oc1..exampleuniqueID`""")
@@ -691,7 +693,7 @@ def post_metric_data(ctx, from_json, metric_data, batch_atomicity):
 
 @suppression_group.command(name=cli_util.override('remove_alarm_suppression.command_name', 'remove'), help=u"""Removes any existing suppression for the specified alarm. For important limits information, see [Limits on Monitoring].
 
-Transactions Per Second (TPS) per-tenancy limit for this operation: 1.""")
+This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations. Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.""")
 @cli_util.option('--alarm-id', required=True, help=u"""The [OCID] of an alarm.""")
 @cli_util.option('--if-match', help=u"""For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource.  The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.""")
 @json_skeleton_utils.get_cli_json_input_option({})
@@ -784,7 +786,7 @@ def summarize_metrics_data(ctx, from_json, compartment_id, namespace, query, res
 
 @alarm_group.command(name=cli_util.override('update_alarm.command_name', 'update'), help=u"""Updates the specified alarm. For important limits information, see [Limits on Monitoring].
 
-Transactions Per Second (TPS) per-tenancy limit for this operation: 1.""")
+This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations. Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests, or transactions, per second (TPS) for a given tenancy.""")
 @cli_util.option('--alarm-id', required=True, help=u"""The [OCID] of an alarm.""")
 @cli_util.option('--display-name', help=u"""A user-friendly name for the alarm. It does not have to be unique, and it's changeable. Avoid entering confidential information.
 
@@ -820,11 +822,13 @@ Example of absence alarm:
 
   -----""")
 @cli_util.option('--resolution', help=u"""The time between calculated aggregation windows for the alarm. Supported value: `1m`""")
-@cli_util.option('--pending-duration', help=u"""The period of time that the condition defined in the alarm must persist before the alarm state changes from \"OK\" to \"FIRING\" or vice versa. For example, a value of 5 minutes means that the alarm must persist in breaching the condition for five minutes before the alarm updates its state to \"FIRING\"; likewise, the alarm must persist in not breaching the condition for five minutes before the alarm updates its state to \"OK.\"
+@cli_util.option('--pending-duration', help=u"""The period of time that the condition defined in the alarm must persist before the alarm state changes from \"OK\" to \"FIRING\". For example, a value of 5 minutes means that the alarm must persist in breaching the condition for five minutes before the alarm updates its state to \"FIRING\".
 
 The duration is specified as a string in ISO 8601 format (`PT10M` for ten minutes or `PT1H` for one hour). Minimum: PT1M. Maximum: PT1H. Default: PT1M.
 
-Under the default value of PT1M, the first evaluation that breaches the alarm updates the state to \"FIRING\" and the first evaluation that does not breach the alarm updates the state to \"OK\".
+Under the default value of PT1M, the first evaluation that breaches the alarm updates the state to \"FIRING\".
+
+The alarm updates its status to \"OK\" when the breaching condition has been clear for the most recent minute.
 
 Example: `PT5M`""")
 @cli_util.option('--severity', help=u"""The perceived severity of the alarm with regard to the affected system.

--- a/services/object_storage/docs/inline-help/os.txt
+++ b/services/object_storage/docs/inline-help/os.txt
@@ -42,11 +42,12 @@ Options:
                   <command> --help.
 
 Commands:
-  create  Creates a bucket in the given namespace with...
-  delete  Deletes a bucket if the bucket is already...
-  get     Gets the current representation of the given...
-  list    Gets a list of all BucketSummary items in a...
-  update  Performs a partial or full update of a...
+  create     Creates a bucket in the given namespace with...
+  delete     Deletes a bucket if the bucket is already...
+  get        Gets the current representation of the given...
+  list       Gets a list of all BucketSummary items in a...
+  reencrypt  Reencrypts the data encryption key of the...
+  update     Performs a partial or full update of a...
 
 ++++++++++++++++++++++++++++++++++++++++++++++
 $ oci os bucket create --help
@@ -105,6 +106,10 @@ Options:
                                   type is set explicitly, the bucket is put in
                                   the Archive Storage tier. The 'storageTier'
                                   property is immutable after bucket is created.
+  --object-events-enabled BOOLEAN
+                                  A property that determines whether events will
+                                  be generated for operations on objects in this
+                                  bucket. This is false by default.
   --freeform-tags COMPLEX TYPE    Free-form tags for this resource. Each tag is
                                   a simple key-value pair with no predefined
                                   name, type, or namespace. For more
@@ -179,8 +184,9 @@ $ oci os bucket delete --help
 Usage: oci os bucket delete [OPTIONS]
 
   Deletes a bucket if the bucket is already empty. If the bucket is not empty,
-  use [DeleteObject] first. You also cannot delete a bucket that has a pre-
-  authenticated request associated with that bucket.
+  use [DeleteObject] first. In addition, you cannot delete a bucket that has a
+  multipart upload in progress or a pre-authenticated request associated with
+  that bucket.
 
 Options:
   -ns, --namespace-name, --namespace TEXT
@@ -361,10 +367,89 @@ Options:
                                   commands, enter <command> --help.
 
 ++++++++++++++++++++++++++++++++++++++++++++++
+$ oci os bucket reencrypt --help
+Usage: oci os bucket reencrypt [OPTIONS]
+
+  Reencrypts the data encryption key of the bucket and objects in the bucket.
+  This is an asynchronous call, the system will start a work request task to
+  reencrypt the data encryption key of the objects and chunks in the bucket.
+  Only the objects created before the time the API call will be reencrypted.
+  The call can take long time depending on how many objects in the bucket and
+  how big the objects are. This API will return a work request id, so the user
+  can use this id to retrieve the status of the work request task.
+
+  A user can update kmsKeyId of the bucket, and then call this API, so the
+  data encryption key of the bucket and objects in the bucket will be
+  reencryped by the new kmsKeyId. Note that the system doesn't maintain what
+  ksmKeyId is used to encrypt the object, the user has to maintain the mapping
+  if they want.
+
+Options:
+  -ns, --namespace-name, --namespace TEXT
+                                  The Object Storage namespace used for the
+                                  request. If not provided, this parameter will
+                                  be obtained internally using a call to 'oci os
+                                  ns get'
+  -bn, --bucket-name TEXT         The name of the bucket. Avoid entering
+                                  confidential information. Example: `my-new-
+                                  bucket1` [required]
+  --wait-for-state [ACCEPTED|IN_PROGRESS|FAILED|COMPLETED|CANCELING|CANCELED]
+                                  This operation asynchronously creates,
+                                  modifies or deletes a resource and uses a work
+                                  request to track the progress of the
+                                  operation. Specify this option to perform the
+                                  action and then wait until the work request
+                                  reaches a certain state. If timeout is
+                                  reached, a return code of 2 is returned. For
+                                  any other error, a return code of 1 is
+                                  returned.
+  --max-wait-seconds INTEGER      The maximum time to wait for the work request
+                                  to reach the state defined by --wait-for-
+                                  state. Defaults to 1200 seconds.
+  --wait-interval-seconds INTEGER
+                                  Check every --wait-interval-seconds to see
+                                  whether the work request to see if it has
+                                  reached the state defined by --wait-for-state.
+                                  Defaults to 30 seconds.
+  --from-json TEXT                Provide input to this command as a JSON
+                                  document from a file using the file://path-
+                                  to/file syntax.
+                                  
+                                  The --generate-full-command-
+                                  json-input option can be used to generate a
+                                  sample json file to be used with this command
+                                  option. The key names are pre-populated and
+                                  match the command option names (converted to
+                                  camelCase format, e.g. compartment-id -->
+                                  compartmentId), while the values of the keys
+                                  need to be populated by the user before using
+                                  the sample file as an input to this command.
+                                  For any command option that accepts multiple
+                                  values, the value of the key can be a JSON
+                                  array.
+                                  
+                                  Options can still be provided on the
+                                  command line. If an option exists in both the
+                                  JSON document and the command line then the
+                                  command line specified value will be used.
+                                  For examples on usage of this option, please
+                                  see our "using CLI with advanced JSON options"
+                                  link: https://docs.cloud.oracle.com/iaas/Conte
+                                  nt/API/SDKDocs/cliusing.htm#AdvancedJSONOption
+                                  s
+  -?, -h, --help                  For detailed help on any of these individual
+                                  commands, enter <command> --help.
+
+++++++++++++++++++++++++++++++++++++++++++++++
 $ oci os bucket update --help
 Usage: oci os bucket update [OPTIONS]
 
   Performs a partial or full update of a bucket's user-defined metadata.
+
+  Use UpdateBucket to move a bucket from one compartment to another within the
+  same tenancy. Supply the compartmentID of the compartment that you want to
+  move the bucket to. For more information about moving resources between
+  compartments, see [Moving Resources to a Different Compartment].
 
 Options:
   -ns, --namespace-name, --namespace TEXT
@@ -376,8 +461,8 @@ Options:
                                   The name of the bucket. Avoid entering
                                   confidential information. Example: `my-new-
                                   bucket1` [required]
-  -c, --compartment-id TEXT       The compartmentId for the compartment to which
-                                  the bucket is targeted to move to.
+  -c, --compartment-id TEXT       The compartmentId for the compartment to move
+                                  the bucket to.
   --metadata COMPLEX TYPE         Arbitrary string, up to 4KB, of keys and
                                   values for user-defined metadata.
                                   This is a
@@ -405,6 +490,10 @@ Options:
                                   When `ObjectReadWithoutList` is enabled on the
                                   bucket, public access is allowed for the
                                   `GetObject` and `HeadObject` operations.
+  --object-events-enabled BOOLEAN
+                                  A property that determines whether events will
+                                  be generated for operations on objects in this
+                                  bucket. This is false by default.
   --freeform-tags COMPLEX TYPE    Free-form tags for this resource. Each tag is
                                   a simple key-value pair with no predefined
                                   name, type, or namespace. For more
@@ -676,10 +765,10 @@ Usage: oci os ns get-metadata [OPTIONS]
   Gets the metadata for the Object Storage namespace, which contains
   defaultS3CompartmentId and defaultSwiftCompartmentId.
 
-  Any user with the NAMESPACE_READ permission will be able to see the current
-  metadata. If you are not authorized, talk to an administrator. If you are an
-  administrator who needs to write policies to give users access, see [Getting
-  Started with Policies].
+  Any user with the OBJECTSTORAGE_NAMESPACE_READ permission will be able to
+  see the current metadata. If you are not authorized, talk to an
+  administrator. If you are an administrator who needs to write policies to
+  give users access, see [Getting Started with Policies].
 
 Options:
   -ns, --namespace-name, --namespace TEXT
@@ -727,8 +816,8 @@ Usage: oci os ns update-metadata [OPTIONS]
   You can change the default Swift/Amazon S3 compartmentId designation to a
   different compartmentId. All subsequent bucket creations will use the new
   default compartment, but no previously created buckets will be modified. A
-  user must have NAMESPACE_UPDATE permission to make changes to the default
-  compartments for Amazon S3 and Swift.
+  user must have OBJECTSTORAGE_NAMESPACE_UPDATE permission to make changes to
+  the default compartments for Amazon S3 and Swift.
 
 Options:
   -ns, --namespace-name, --namespace TEXT
@@ -1202,6 +1291,8 @@ Options:
                                   upload times, but the upload process will
                                   consume more system resources and network
                                   bandwidth. [default: 10]
+  --verify-checksum               Verify the checksum of the uploaded object
+                                  with the local file.
   --include TEXT                  Only upload files which match the provided
                                   pattern. Patterns are taken relative to the
                                   CURRENT directory. This option can be provided
@@ -1693,6 +1784,8 @@ Options:
                                   in parallel. This option cannot be used with
                                   --disable-parallel-uploads or --no-multipart.
                                   Defaults to 3.
+  --verify-checksum               Verify the checksum of the uploaded object
+                                  with the local file.
   --from-json TEXT                Provide input to this command as a JSON
                                   document from a file using the file://path-
                                   to/file syntax.

--- a/services/object_storage/tests/integ/test_object_storage_bulk_operations.py
+++ b/services/object_storage/tests/integ/test_object_storage_bulk_operations.py
@@ -370,6 +370,16 @@ def test_bulk_put_default_options():
     for object_name in object_name_set:
         assert object_name in parsed_result['uploaded-objects']
 
+    result = invoke(['os', 'object', 'bulk-upload', '--namespace', util.NAMESPACE, '--bucket-name', bulk_put_bucket_name, '--src-dir', root_bulk_put_folder, '--overwrite', '--verify-checksum'])
+
+    # No failures or skips and we uploaded everything
+    parsed_result = parse_json_response_from_mixed_output(result.output)
+    assert parsed_result['skipped-objects'] == []
+    assert parsed_result['upload-failures'] == {}
+    assert len(parsed_result['uploaded-objects']) == get_count_of_files_in_folder_and_subfolders(root_bulk_put_folder)
+    for uploaded_object_name in parsed_result['uploaded-objects']:
+        assert "md5 checksum matches" in parsed_result['uploaded-objects'][uploaded_object_name]['verify-md5-checksum']
+
     shutil.rmtree(download_folder)
 
 
@@ -383,6 +393,20 @@ def test_bulk_put_auto_content_type():
     assert parsed_result['skipped-objects'] == []
     assert parsed_result['upload-failures'] == {}
     assert len(parsed_result['uploaded-objects']) == get_count_of_files_in_folder_and_subfolders(root_bulk_put_folder)
+
+    result = invoke([
+        'os', 'object', 'bulk-upload',
+        '--namespace', util.NAMESPACE,
+        '--bucket-name', bulk_put_bucket_name,
+        '--src-dir', root_bulk_put_folder,
+        '--content-type', 'auto', '--overwrite', '--verify-checksum'
+    ])
+    parsed_result = parse_json_response_from_mixed_output(result.output)
+    assert parsed_result['skipped-objects'] == []
+    assert parsed_result['upload-failures'] == {}
+    assert len(parsed_result['uploaded-objects']) == get_count_of_files_in_folder_and_subfolders(root_bulk_put_folder)
+    for uploaded_object_name in parsed_result['uploaded-objects']:
+        assert "md5 checksum matches" in parsed_result['uploaded-objects'][uploaded_object_name]['verify-md5-checksum']
 
     # Pull everything down and verify that the files match (everything in source appears in destination and they are equal)
     download_folder = 'tests/temp/verify_files_{}'.format(bulk_put_bucket_name)
@@ -441,6 +465,20 @@ def test_bulk_put_with_multipart_params(object_storage_client):
     assert parsed_result['upload-failures'] == {}
     assert len(parsed_result['uploaded-objects']) == get_count_of_files_in_folder_and_subfolders(root_bulk_put_folder)
 
+    result = invoke([
+        'os', 'object', 'bulk-upload',
+        '--namespace', util.NAMESPACE,
+        '--bucket-name', create_bucket_request.name,
+        '--src-dir', root_bulk_put_folder,
+        '--no-multipart', '--overwrite', '--verify-checksum'
+    ])
+    parsed_result = parse_json_response_from_mixed_output(result.output)
+    assert parsed_result['skipped-objects'] == []
+    assert parsed_result['upload-failures'] == {}
+    assert len(parsed_result['uploaded-objects']) == get_count_of_files_in_folder_and_subfolders(root_bulk_put_folder)
+    for uploaded_object_name in parsed_result['uploaded-objects']:
+        assert "md5 checksum matches" in parsed_result['uploaded-objects'][uploaded_object_name]['verify-md5-checksum']
+
     delete_bucket_and_all_items(object_storage_client, create_bucket_request.name)
 
 
@@ -453,6 +491,20 @@ def test_bulk_put_with_prefix():
     assert parsed_result['skipped-objects'] == []
     assert parsed_result['upload-failures'] == {}
     assert len(parsed_result['uploaded-objects']) == get_count_of_files_in_folder_and_subfolders(root_bulk_put_folder)
+
+    result = invoke([
+        'os', 'object', 'bulk-upload',
+        '--namespace', util.NAMESPACE,
+        '--bucket-name', bulk_put_bucket_name,
+        '--src-dir', root_bulk_put_folder,
+        '--object-prefix', 'bulk_put_prefix_test/', '--overwrite', '--verify-checksum'
+    ])
+    parsed_result = parse_json_response_from_mixed_output(result.output)
+    assert parsed_result['skipped-objects'] == []
+    assert parsed_result['upload-failures'] == {}
+    assert len(parsed_result['uploaded-objects']) == get_count_of_files_in_folder_and_subfolders(root_bulk_put_folder)
+    for uploaded_object_name in parsed_result['uploaded-objects']:
+        assert "md5 checksum matches" in parsed_result['uploaded-objects'][uploaded_object_name]['verify-md5-checksum']
 
     download_folder = 'tests/temp/verify_files_bulk_put_prefix_{}'.format(bulk_put_bucket_name)
     invoke(['os', 'object', 'bulk-download', '--namespace', util.NAMESPACE, '--bucket-name', bulk_put_bucket_name, '--download-dir', download_folder, '--prefix', 'bulk_put_prefix_test/'])

--- a/services/object_storage/tests/integ/test_object_storage_multipart.py
+++ b/services/object_storage/tests/integ/test_object_storage_multipart.py
@@ -110,6 +110,15 @@ def test_multipart_put_object(runner, config_file, config_profile, temp_bucket, 
     assert checksum_md5(content_input_file) == checksum_md5(CONTENT_OUTPUT_FILE)
     assert os.stat(content_input_file).st_size == os.stat(CONTENT_OUTPUT_FILE).st_size
 
+    # object put (large file so multipart is used)
+    result = invoke(runner, config_file, config_profile, ['object', 'put', '-ns', util.NAMESPACE, '-bn', temp_bucket,
+                                                          '--name', object_name, '--file', content_input_file,
+                                                          '--part-size', str(DEFAULT_TEST_PART_SIZE),
+                                                          '--force',
+                                                          '--verify-checksum'])
+    validate_response(result, json_response_expected=False)
+    assert "md5 checksum matches" in result.output
+
     # object delete
     result = invoke(runner, config_file, config_profile,
                     ['object', 'delete', '-ns', util.NAMESPACE, '-bn', temp_bucket, '--name', object_name], input='y')

--- a/services/resource_manager/docs/inline-help/resource-manager.txt
+++ b/services/resource_manager/docs/inline-help/resource-manager.txt
@@ -16,11 +16,9 @@ Options:
                   <command> --help.
 
 Commands:
-  job                     Jobs perform the actions that are defined in...
-  stack                   The stack object.
-  work-request            The status of a work request.
-  work-request-error      An error encountered while executing a work...
-  work-request-log-entry  A log message from the execution of a work...
+  job           Jobs perform the actions that are defined in...
+  stack         The stack object.
+  work-request  The status of a work request.
 
 ++++++++++++++++++++++++++++++++++++++++++++++
 $ oci resource-manager job --help
@@ -1143,13 +1141,14 @@ Options:
                   <command> --help.
 
 Commands:
-  change-compartment   Moves a Stack and it's associated Jobs into a...
-  create               Creates a Stack
-  delete               Deletes the specified stack object.
-  get                  Gets a stack using the stack ID.
-  get-stack-tf-config  Returns the Terraform configuration file in...
-  list                 Returns a list of stacks.
-  update               Update the Stack object
+  change-compartment       Moves a Stack and it's associated Jobs into a...
+  create                   Creates a Stack
+  delete                   Deletes the specified stack object.
+  get                      Gets a stack using the stack ID.
+  get-stack-tf-config      Returns the Terraform configuration file in...
+  list                     Returns a list of stacks.
+  list-terraform-versions  Returns a list of supported Terraform...
+  update                   Update the Stack object
 
 ++++++++++++++++++++++++++++++++++++++++++++++
 $ oci resource-manager stack change-compartment --help
@@ -1246,6 +1245,7 @@ Options:
                                   in
                                   a file, modifying it as needed and then
                                   passing it back in via the file:// syntax.
+  --terraform-version TEXT        The stack's Terraform version
   --freeform-tags COMPLEX TYPE    Free-form tags associated with this resource.
                                   Each tag is a simple key-value pair with no
                                   predefined name, type, or namespace. For more
@@ -1534,6 +1534,41 @@ Options:
                                   commands, enter <command> --help.
 
 ++++++++++++++++++++++++++++++++++++++++++++++
+$ oci resource-manager stack list-terraform-versions --help
+Usage: oci resource-manager stack list-terraform-versions [OPTIONS]
+
+  Returns a list of supported Terraform versions in a compartment.
+
+Options:
+  -c, --compartment-id TEXT  The compartment OCID on which to filter.
+  --all                      Fetches all pages of results.
+  --from-json TEXT           Provide input to this command as a JSON document
+                             from a file using the file://path-to/file syntax.
+                             The --generate-full-command-json-input option can
+                             be used to generate a sample json file to be used
+                             with this command option. The key names are pre-
+                             populated and match the command option names
+                             (converted to camelCase format, e.g. compartment-id
+                             --> compartmentId), while the values of the keys
+                             need to be populated by the user before using the
+                             sample file as an input to this command. For any
+                             command option that accepts multiple values, the
+                             value of the key can be a JSON array.
+                             
+                             Options can
+                             still be provided on the command line. If an option
+                             exists in both the JSON document and the command
+                             line then the command line specified value will be
+                             used.
+                             
+                             For examples on usage of this option, please
+                             see our "using CLI with advanced JSON options"
+                             link: https://docs.cloud.oracle.com/iaas/Content/AP
+                             I/SDKDocs/cliusing.htm#AdvancedJSONOptions
+  -?, -h, --help             For detailed help on any of these individual
+                             commands, enter <command> --help.
+
+++++++++++++++++++++++++++++++++++++++++++++++
 $ oci resource-manager stack update --help
 Usage: oci resource-manager stack update [OPTIONS]
 
@@ -1563,6 +1598,7 @@ Options:
                                   in
                                   a file, modifying it as needed and then
                                   passing it back in via the file:// syntax.
+  --terraform-version TEXT        The Terraform version of the stack.
   --freeform-tags COMPLEX TYPE    Free-form tags associated with this resource.
                                   Each tag is a simple key-value pair with no
                                   predefined name, type, or namespace. For more
@@ -1669,8 +1705,9 @@ Options:
                   <command> --help.
 
 Commands:
-  get   Return the given work request.
-  list  Lists the work requests in a given...
+  get                       Return the given work request.
+  list                      Lists the work requests in a given...
+  list-work-request-errors  Return a (paginated) list of errors for a...
 
 ++++++++++++++++++++++++++++++++++++++++++++++
 $ oci resource-manager work-request get --help
@@ -1752,84 +1789,11 @@ Options:
                              commands, enter <command> --help.
 
 ++++++++++++++++++++++++++++++++++++++++++++++
-$ oci resource-manager work-request-error --help
-Usage: oci resource-manager work-request-error [OPTIONS] COMMAND [ARGS]...
-
-  An error encountered while executing a work request.
-
-Options:
-  -?, -h, --help  For detailed help on any of these individual commands, enter
-                  <command> --help.
-
-Commands:
-  list  Return a (paginated) list of errors for a...
-
-++++++++++++++++++++++++++++++++++++++++++++++
-$ oci resource-manager work-request-error list --help
-Usage: oci resource-manager work-request-error list [OPTIONS]
+$ oci resource-manager work-request list-work-request-errors --help
+Usage: oci resource-manager work-request list-work-request-errors 
+           [OPTIONS]
 
   Return a (paginated) list of errors for a given work request.
-
-Options:
-  --work-request-id TEXT     The OCID of the work request. [required]
-  -c, --compartment-id TEXT  The compartment OCID on which to filter.
-  --limit INTEGER            The number of items returned in a paginated `List`
-                             call. For information about pagination, see [List
-                             Pagination].
-  --page TEXT                The value of the `opc-next-page` response header
-                             from the preceding `List` call. For information
-                             about pagination, see [List Pagination].
-  --sort-order [ASC|DESC]    The sort order, either `ASC` (ascending) or `DESC`
-                             (descending).
-  --all                      Fetches all pages of results. If you provide this
-                             option, then you cannot provide the --limit option.
-  --page-size INTEGER        When fetching results, the number of results to
-                             fetch per call. Only valid when used with --all or
-                             --limit, and ignored otherwise.
-  --from-json TEXT           Provide input to this command as a JSON document
-                             from a file using the file://path-to/file syntax.
-                             The --generate-full-command-json-input option can
-                             be used to generate a sample json file to be used
-                             with this command option. The key names are pre-
-                             populated and match the command option names
-                             (converted to camelCase format, e.g. compartment-id
-                             --> compartmentId), while the values of the keys
-                             need to be populated by the user before using the
-                             sample file as an input to this command. For any
-                             command option that accepts multiple values, the
-                             value of the key can be a JSON array.
-                             
-                             Options can
-                             still be provided on the command line. If an option
-                             exists in both the JSON document and the command
-                             line then the command line specified value will be
-                             used.
-                             
-                             For examples on usage of this option, please
-                             see our "using CLI with advanced JSON options"
-                             link: https://docs.cloud.oracle.com/iaas/Content/AP
-                             I/SDKDocs/cliusing.htm#AdvancedJSONOptions
-  -?, -h, --help             For detailed help on any of these individual
-                             commands, enter <command> --help.
-
-++++++++++++++++++++++++++++++++++++++++++++++
-$ oci resource-manager work-request-log-entry --help
-Usage: oci resource-manager work-request-log-entry [OPTIONS] COMMAND [ARGS]...
-
-  A log message from the execution of a work request.
-
-Options:
-  -?, -h, --help  For detailed help on any of these individual commands, enter
-                  <command> --help.
-
-Commands:
-  list  Return a (paginated) list of logs for a given...
-
-++++++++++++++++++++++++++++++++++++++++++++++
-$ oci resource-manager work-request-log-entry list --help
-Usage: oci resource-manager work-request-log-entry list [OPTIONS]
-
-  Return a (paginated) list of logs for a given work request.
 
 Options:
   --work-request-id TEXT     The OCID of the work request. [required]

--- a/services/resource_manager/src/oci_cli_resource_manager/generated/resourcemanager_cli.py
+++ b/services/resource_manager/src/oci_cli_resource_manager/generated/resourcemanager_cli.py
@@ -26,18 +26,6 @@ def stack_group():
     pass
 
 
-@click.command(cli_util.override('work_request_error_group.command_name', 'work-request-error'), cls=CommandGroupWithAlias, help="""An error encountered while executing a work request.""")
-@cli_util.help_option_group
-def work_request_error_group():
-    pass
-
-
-@click.command(cli_util.override('work_request_log_entry_group.command_name', 'work-request-log-entry'), cls=CommandGroupWithAlias, help="""A log message from the execution of a work request.""")
-@cli_util.help_option_group
-def work_request_log_entry_group():
-    pass
-
-
 @click.command(cli_util.override('work_request_group.command_name', 'work-request'), cls=CommandGroupWithAlias, help="""The status of a work request.""")
 @cli_util.help_option_group
 def work_request_group():
@@ -51,8 +39,6 @@ def job_group():
 
 
 resource_manager_root_group.add_command(stack_group)
-resource_manager_root_group.add_command(work_request_error_group)
-resource_manager_root_group.add_command(work_request_log_entry_group)
 resource_manager_root_group.add_command(work_request_group)
 resource_manager_root_group.add_command(job_group)
 
@@ -550,6 +536,7 @@ def create_job_create_destroy_job_operation_details(ctx, from_json, wait_for_sta
 @cli_util.option('--display-name', help=u"""The stack's display name.""")
 @cli_util.option('--description', help=u"""Description of the stack.""")
 @cli_util.option('--variables', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Terraform variables associated with this resource. Maximum number of variables supported is 100. The maximum size of each variable, including both name and value, is 4096 bytes. Example: `{\"CompartmentId\": \"compartment-id-value\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
+@cli_util.option('--terraform-version', help=u"""The stack's Terraform version""")
 @cli_util.option('--freeform-tags', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Free-form tags associated with this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags]. Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--defined-tags', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Defined tags associated with this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags]. Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--wait-for-state', type=custom_types.CliCaseInsensitiveChoice(["CREATING", "ACTIVE", "DELETING", "DELETED"]), help="""This operation creates, modifies or deletes a resource that has a defined lifecycle state. Specify this option to perform the action and then wait until the resource reaches a given lifecycle state. If timeout is reached, a return code of 2 is returned. For any other error, a return code of 1 is returned.""")
@@ -560,7 +547,7 @@ def create_job_create_destroy_job_operation_details(ctx, from_json, wait_for_sta
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={'config-source': {'module': 'resource_manager', 'class': 'CreateConfigSourceDetails'}, 'variables': {'module': 'resource_manager', 'class': 'dict(str, string)'}, 'freeform-tags': {'module': 'resource_manager', 'class': 'dict(str, string)'}, 'defined-tags': {'module': 'resource_manager', 'class': 'dict(str, dict(str, object))'}}, output_type={'module': 'resource_manager', 'class': 'Stack'})
 @cli_util.wrap_exceptions
-def create_stack(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, compartment_id, config_source, display_name, description, variables, freeform_tags, defined_tags):
+def create_stack(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, compartment_id, config_source, display_name, description, variables, terraform_version, freeform_tags, defined_tags):
 
     kwargs = {}
     kwargs['opc_request_id'] = cli_util.use_or_generate_request_id(ctx.obj['request_id'])
@@ -577,6 +564,9 @@ def create_stack(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval
 
     if variables is not None:
         details['variables'] = cli_util.parse_json_parameter("variables", variables)
+
+    if terraform_version is not None:
+        details['terraformVersion'] = terraform_version
 
     if freeform_tags is not None:
         details['freeformTags'] = cli_util.parse_json_parameter("freeform_tags", freeform_tags)
@@ -620,6 +610,7 @@ def create_stack(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval
 @cli_util.option('--display-name', help=u"""The stack's display name.""")
 @cli_util.option('--description', help=u"""Description of the stack.""")
 @cli_util.option('--variables', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Terraform variables associated with this resource. Maximum number of variables supported is 100. The maximum size of each variable, including both name and value, is 4096 bytes. Example: `{\"CompartmentId\": \"compartment-id-value\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
+@cli_util.option('--terraform-version', help=u"""The stack's Terraform version""")
 @cli_util.option('--freeform-tags', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Free-form tags associated with this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags]. Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--defined-tags', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Defined tags associated with this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags]. Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--config-source-working-directory', help=u"""File path to the directory from which Terraform runs. If not specified, the root directory is used.""")
@@ -631,7 +622,7 @@ def create_stack(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={'variables': {'module': 'resource_manager', 'class': 'dict(str, string)'}, 'freeform-tags': {'module': 'resource_manager', 'class': 'dict(str, string)'}, 'defined-tags': {'module': 'resource_manager', 'class': 'dict(str, dict(str, object))'}}, output_type={'module': 'resource_manager', 'class': 'Stack'})
 @cli_util.wrap_exceptions
-def create_stack_create_zip_upload_config_source_details(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, compartment_id, config_source_zip_file_base64_encoded, display_name, description, variables, freeform_tags, defined_tags, config_source_working_directory):
+def create_stack_create_zip_upload_config_source_details(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, compartment_id, config_source_zip_file_base64_encoded, display_name, description, variables, terraform_version, freeform_tags, defined_tags, config_source_working_directory):
 
     kwargs = {}
     kwargs['opc_request_id'] = cli_util.use_or_generate_request_id(ctx.obj['request_id'])
@@ -649,6 +640,9 @@ def create_stack_create_zip_upload_config_source_details(ctx, from_json, wait_fo
 
     if variables is not None:
         details['variables'] = cli_util.parse_json_parameter("variables", variables)
+
+    if terraform_version is not None:
+        details['terraformVersion'] = terraform_version
 
     if freeform_tags is not None:
         details['freeformTags'] = cli_util.parse_json_parameter("freeform_tags", freeform_tags)
@@ -1153,7 +1147,28 @@ def list_stacks(ctx, from_json, all_pages, page_size, compartment_id, id, lifecy
     cli_util.render_response(result, ctx)
 
 
-@work_request_error_group.command(name=cli_util.override('list_work_request_errors.command_name', 'list'), help=u"""Return a (paginated) list of errors for a given work request.""")
+@stack_group.command(name=cli_util.override('list_terraform_versions.command_name', 'list-terraform-versions'), help=u"""Returns a list of supported Terraform versions in a compartment.""")
+@cli_util.option('--compartment-id', help=u"""The compartment OCID on which to filter.""")
+@cli_util.option('--all', 'all_pages', is_flag=True, help="""Fetches all pages of results.""")
+@json_skeleton_utils.get_cli_json_input_option({})
+@cli_util.help_option
+@click.pass_context
+@json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={}, output_type={'module': 'resource_manager', 'class': 'TerraformVersionCollection'})
+@cli_util.wrap_exceptions
+def list_terraform_versions(ctx, from_json, all_pages, compartment_id):
+
+    kwargs = {}
+    if compartment_id is not None:
+        kwargs['compartment_id'] = compartment_id
+    kwargs['opc_request_id'] = cli_util.use_or_generate_request_id(ctx.obj['request_id'])
+    client = cli_util.build_client('resource_manager', ctx)
+    result = client.list_terraform_versions(
+        **kwargs
+    )
+    cli_util.render_response(result, ctx)
+
+
+@work_request_group.command(name=cli_util.override('list_work_request_errors.command_name', 'list-work-request-errors'), help=u"""Return a (paginated) list of errors for a given work request.""")
 @cli_util.option('--work-request-id', required=True, help=u"""The OCID of the work request.""")
 @cli_util.option('--compartment-id', help=u"""The compartment OCID on which to filter.""")
 @cli_util.option('--limit', type=click.INT, help=u"""The number of items returned in a paginated `List` call. For information about pagination, see [List Pagination].""")
@@ -1210,7 +1225,7 @@ def list_work_request_errors(ctx, from_json, all_pages, page_size, work_request_
     cli_util.render_response(result, ctx)
 
 
-@work_request_log_entry_group.command(name=cli_util.override('list_work_request_logs.command_name', 'list-work-request-logs'), help=u"""Return a (paginated) list of logs for a given work request.""")
+@work_request_group.command(name=cli_util.override('list_work_request_logs.command_name', 'list-work-request-logs'), help=u"""Return a (paginated) list of logs for a given work request.""")
 @cli_util.option('--work-request-id', required=True, help=u"""The OCID of the work request.""")
 @cli_util.option('--compartment-id', help=u"""The compartment OCID on which to filter.""")
 @cli_util.option('--limit', type=click.INT, help=u"""The number of items returned in a paginated `List` call. For information about pagination, see [List Pagination].""")
@@ -1395,6 +1410,7 @@ def update_job(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_int
 @cli_util.option('--description', help=u"""Description of the stack.""")
 @cli_util.option('--config-source', type=custom_types.CLI_COMPLEX_TYPE, help=u"""""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--variables', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Terraform variables associated with this resource. The maximum number of variables supported is 100. The maximum size of each variable, including both name and value, is 4096 bytes. Example: `{\"CompartmentId\": \"compartment-id-value\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
+@cli_util.option('--terraform-version', help=u"""The Terraform version of the stack.""")
 @cli_util.option('--freeform-tags', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Free-form tags associated with this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags]. Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--defined-tags', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags]. Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--if-match', help=u"""For optimistic concurrency control. In the `PUT` or `DELETE` call for a resource, set the `if-match` parameter to the value of the etag from a previous `GET` or `POST` response for that resource.  The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.""")
@@ -1407,7 +1423,7 @@ def update_job(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_int
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={'config-source': {'module': 'resource_manager', 'class': 'UpdateConfigSourceDetails'}, 'variables': {'module': 'resource_manager', 'class': 'dict(str, string)'}, 'freeform-tags': {'module': 'resource_manager', 'class': 'dict(str, string)'}, 'defined-tags': {'module': 'resource_manager', 'class': 'dict(str, dict(str, object))'}}, output_type={'module': 'resource_manager', 'class': 'Stack'})
 @cli_util.wrap_exceptions
-def update_stack(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_interval_seconds, stack_id, display_name, description, config_source, variables, freeform_tags, defined_tags, if_match):
+def update_stack(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_interval_seconds, stack_id, display_name, description, config_source, variables, terraform_version, freeform_tags, defined_tags, if_match):
 
     if isinstance(stack_id, six.string_types) and len(stack_id.strip()) == 0:
         raise click.UsageError('Parameter --stack-id cannot be whitespace or empty string')
@@ -1434,6 +1450,9 @@ def update_stack(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_i
 
     if variables is not None:
         details['variables'] = cli_util.parse_json_parameter("variables", variables)
+
+    if terraform_version is not None:
+        details['terraformVersion'] = terraform_version
 
     if freeform_tags is not None:
         details['freeformTags'] = cli_util.parse_json_parameter("freeform_tags", freeform_tags)
@@ -1477,6 +1496,7 @@ def update_stack(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_i
 @cli_util.option('--display-name', help=u"""The name of the stack.""")
 @cli_util.option('--description', help=u"""Description of the stack.""")
 @cli_util.option('--variables', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Terraform variables associated with this resource. The maximum number of variables supported is 100. The maximum size of each variable, including both name and value, is 4096 bytes. Example: `{\"CompartmentId\": \"compartment-id-value\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
+@cli_util.option('--terraform-version', help=u"""The Terraform version of the stack.""")
 @cli_util.option('--freeform-tags', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Free-form tags associated with this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags]. Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--defined-tags', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags]. Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--if-match', help=u"""For optimistic concurrency control. In the `PUT` or `DELETE` call for a resource, set the `if-match` parameter to the value of the etag from a previous `GET` or `POST` response for that resource.  The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.""")
@@ -1491,7 +1511,7 @@ def update_stack(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_i
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={'variables': {'module': 'resource_manager', 'class': 'dict(str, string)'}, 'freeform-tags': {'module': 'resource_manager', 'class': 'dict(str, string)'}, 'defined-tags': {'module': 'resource_manager', 'class': 'dict(str, dict(str, object))'}}, output_type={'module': 'resource_manager', 'class': 'Stack'})
 @cli_util.wrap_exceptions
-def update_stack_update_zip_upload_config_source_details(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_interval_seconds, stack_id, display_name, description, variables, freeform_tags, defined_tags, if_match, config_source_working_directory, config_source_zip_file_base64_encoded):
+def update_stack_update_zip_upload_config_source_details(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_interval_seconds, stack_id, display_name, description, variables, terraform_version, freeform_tags, defined_tags, if_match, config_source_working_directory, config_source_zip_file_base64_encoded):
 
     if isinstance(stack_id, six.string_types) and len(stack_id.strip()) == 0:
         raise click.UsageError('Parameter --stack-id cannot be whitespace or empty string')
@@ -1516,6 +1536,9 @@ def update_stack_update_zip_upload_config_source_details(ctx, from_json, force, 
 
     if variables is not None:
         details['variables'] = cli_util.parse_json_parameter("variables", variables)
+
+    if terraform_version is not None:
+        details['terraformVersion'] = terraform_version
 
     if freeform_tags is not None:
         details['freeformTags'] = cli_util.parse_json_parameter("freeform_tags", freeform_tags)

--- a/services/waas/docs/inline-help/waas.txt
+++ b/services/waas/docs/inline-help/waas.txt
@@ -3404,8 +3404,8 @@ Options:
                                   address and prevents spoofing.
                                   
                                   -
-                                  **X_FORWARDED_FOR:** Corresponds to
-                                  `X-Forwarded-For` header name.
+                                  **X_FORWARDED_FOR:** Corresponds to `X
+                                  -Forwarded-For` header name.
                                   
                                   -
                                   **X_CLIENT_IP:** Corresponds to `X-Client-Ip`
@@ -3442,20 +3442,19 @@ Options:
                                   ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-
                                   SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-
                                   AES128-GCM-SHA256:DHE-DSS-AES128-GCM-
-                                  SHA256:kEDH+AESGCM:ECDHE-RSA-
-                                  AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-
-                                  RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-
-                                  RSA-AES256-SHA384:ECDHE-ECDSA-
-                                  AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-
-                                  ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-
-                                  RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-
-                                  AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-
-                                  AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384
-                                  :AES128-SHA256:AES256-SHA256:AES128-SHA:AES256
-                                  -SHA:AES:CAMELLIA:!DES-CBC3-SHA:!aNULL:!eNULL:
-                                  !EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-
-                                  DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-
-                                  CBC3-SHA`
+                                  SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256
+                                  :ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-
+                                  AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-
+                                  AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-
+                                  RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-
+                                  AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-
+                                  AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-
+                                  AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-
+                                  SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-
+                                  SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA
+                                  :!DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4
+                                  :!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-
+                                  RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA`
   --if-match TEXT                 For optimistic concurrency control. In the
                                   `PUT` or `DELETE` call for a resource, set the
                                   `if-match` parameter to the value of the etag

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open_relative("README.rst") as f:
     readme = f.read()
 
 requires = [
-    'oci==2.5.0',
+    'oci==2.5.1',
     'arrow==0.10.0',
     'certifi',
     'click==6.7',

--- a/src/oci_cli/version.py
+++ b/src/oci_cli/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = '2.6.5'
+__version__ = '2.6.6'


### PR DESCRIPTION
### Added
* ``--verify-checksum`` option for the following commands: ``oci os object put`` and ``oci os object bulk-upload``. This option will print a message indicating whether the checksum for the uploaded file matches the local file. Sample message: 'md5 checksum matches [Local: AikPDj8xbhaUNKeS956p1A==]'

* Support for re-encrypting a bucket.

  * ``oci os bucket reencrypt --namespace-name --bucket-name``

* Support for enabling/disabling bucket level events.

  * ``oci os bucket create --object-events-enabled``
  * ``oci os bucket update --object-events-enabled``

* Improve Autonomous Database to change the whitelist ips feature.

  * ``oci db autonomous-database update --whitelisted-ips``

* Support for Autonomous Database to create with the whitelist ips feature.

  * ``oci db autonomous-database create --whitelisted-ips``

### Changed
* Default CreateKubeconfig so it uses token version 2.0.0

  * ``oci ce cluster create-kubeconfig``

### Fixed
* ``oci session authenticate`` was not correctly redirecting to the correct URL for government regions

