### PR TITLE
Releasing version 2.6.12

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,41 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`__.
 
+2.6.12 - 2019-11-12
+-------------------
+Added
+~~~~~
+* Support to register and deregister an autonomous data warehouse, or autonomous transaction processing, database with Data Safe.
+
+  * ``oci db autonomous-database data-safe register --autonomous-database-id <autonomous database OCID>``
+  * ``oci db autonomous-database data-safe deregister --autonomous-database-id <autonomous database OCID>`` 
+
+* Add capability to redirect an input HTTP/HTTPS request URI to a different URI in Load Balancer service.
+
+  * ``oci lb rule-set create --items``
+
+* Console access to APEX and SQL Dev features for Create and Update ATP/ADW in the Database service
+
+* Support for Volume Performance Units for Block Volumes in Block Storage service.
+
+  * ``oci bv boot-volume create --vpus-per-gb``
+  * ``oci bv boot-volume update --vpus-per-gb``
+
+* Support for specifying compartment for OKE options APIs
+
+  * ``oci ce cluster-options get --compartment-id``
+  * ``oci ce node-pool-options get --compartment-id``
+
+* Support for HTTP raw requests
+
+  * ``oci raw-request``
+
+* Deprecation warning message for python 2. This can be turned-off by setting the environment variable ``SUPPRESS_PYTHON2_WARNING``.
+
+Changed
+~~~~~~~
+* Removed deprecated ``bmcs`` entry point for CLI. Now only ``oci`` is supported.  
+
 2.6.11 - 2019-11-5
 -------------------
 Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ Jinja2==2.10.1
 jmespath==0.9.3
 ndg-httpsclient==0.4.2
 mock==2.0.0
-oci==2.6.3
+oci==2.6.4
 packaging==16.8
 pluggy==0.4.0
 py==1.4.33

--- a/scripts/basic_cli_test_script.sh
+++ b/scripts/basic_cli_test_script.sh
@@ -26,8 +26,6 @@ LARGE_FILE_PATH=scripts/temp/large_file
 LARGE_FILE_DOWNLOAD_PATH=scripts/temp/large_file_downloaded
 ARGS="--config-file $OCI_CLI_CONFIG_FILE"
 
-# test that invoking with deprecated entry point 'bmcs' still works
-bmcs $ARGS os ns get
 oci $ARGS os ns get
 oci $ARGS os bucket create -ns $NS --compartment-id $C --name $BUCKET
 echo 'example object content!' > $FILE

--- a/scripts/install/install.py
+++ b/scripts/install/install.py
@@ -53,8 +53,6 @@ DEFAULT_INSTALL_DIR = os.path.expanduser(os.path.join('~', 'lib', 'oracle-cli'))
 DEFAULT_EXEC_DIR = os.path.expanduser(os.path.join('~', 'bin'))
 DEFAULT_SCRIPT_DIR = os.path.expanduser(os.path.join('~', 'bin', 'oci-cli-scripts'))
 OCI_EXECUTABLE_NAME = 'oci.exe' if is_windows() else 'oci'
-# 'bmcs' is deprecated and is retained for backwards compatibiity, it will be removed completely in March 2018.
-BMCS_EXECUTABLE_NAME = 'bmcs.exe' if is_windows() else 'bmcs'
 DBAAS_SCRIPT_NAME = 'create_backup_from_onprem.exe' if is_windows() else 'create_backup_from_onprem'
 
 USER_BASH_RC = os.path.expanduser(os.path.join('~', '.bashrc'))
@@ -362,21 +360,18 @@ def get_rc_file_path():
     return None
 
 
-def warn_other_oci_or_bmcs_on_path(exec_dir, exec_filepath):
+def warn_other_oci_on_path(exec_dir, exec_filepath):
     env_path = os.environ.get('PATH')
     conflicting_paths = []
     if env_path:
         for p in env_path.split(':'):
             p_to_oci = os.path.join(p, OCI_EXECUTABLE_NAME)
-            p_to_bmcs = os.path.join(p, BMCS_EXECUTABLE_NAME)
             if p != exec_dir:
                 if os.path.isfile(p_to_oci):
                     conflicting_paths.append(p_to_oci)
-                if os.path.isfile(p_to_bmcs):
-                    conflicting_paths.append(p_to_bmcs)
     if conflicting_paths:
         print_status()
-        print_status("** WARNING: Other '{}' or '{}' executables are on your $PATH. **".format(OCI_EXECUTABLE_NAME, BMCS_EXECUTABLE_NAME))
+        print_status("** WARNING: Other '{}' executables are on your $PATH. **".format(OCI_EXECUTABLE_NAME))
         print_status("Conflicting paths: {}".format(', '.join(conflicting_paths)))
         print_status("You can run this installation of the CLI with '{}'.".format(exec_filepath))
 
@@ -448,7 +443,7 @@ def handle_path_and_tab_completion(completion_file_path, exec_filepath, exec_dir
             _modify_rc(rc_file_path, line_to_add)
             print_status('Tab completion set up complete.')
             print_status("If tab completion is not activated, verify that '{}' is sourced by your shell.".format(rc_file_path))
-            warn_other_oci_or_bmcs_on_path(exec_dir, exec_filepath)
+            warn_other_oci_on_path(exec_dir, exec_filepath)
             print_status()
             print_status('** Run `exec -l $SHELL` to restart your shell. **')
             print_status()
@@ -609,10 +604,8 @@ def main():
         OPTIONAL_FEATURES = get_optional_features()
 
     oci_exec_path = os.path.join(exec_dir, OCI_EXECUTABLE_NAME)
-    bmcs_exec_path = os.path.join(exec_dir, BMCS_EXECUTABLE_NAME)
     dbaas_exec_path = os.path.join(script_dir, DBAAS_SCRIPT_NAME)
     verify_install_dir_exec_path_conflict(install_dir, oci_exec_path)
-    verify_install_dir_exec_path_conflict(install_dir, bmcs_exec_path)
     create_virtualenv(tmp_dir, install_dir)
     install_cli(install_dir, tmp_dir, args.oci_cli_version, OPTIONAL_FEATURES)
 
@@ -627,19 +620,15 @@ def main():
 
         # copy the executable created from the pip install to the bin directory specified by the user
         shutil.copyfile(os.path.join(install_dir, 'Scripts', OCI_EXECUTABLE_NAME), oci_exec_path)
-        shutil.copyfile(os.path.join(install_dir, 'Scripts', BMCS_EXECUTABLE_NAME), bmcs_exec_path)
         shutil.copyfile(os.path.join(install_dir, 'Scripts', DBAAS_SCRIPT_NAME), dbaas_exec_path)
     else:
         # copy the executable created from the pip install to the bin directory specified by the user
         shutil.copyfile(os.path.join(install_dir, 'bin', OCI_EXECUTABLE_NAME), oci_exec_path)
-        shutil.copyfile(os.path.join(install_dir, 'bin', BMCS_EXECUTABLE_NAME), bmcs_exec_path)
         shutil.copyfile(os.path.join(install_dir, 'bin', DBAAS_SCRIPT_NAME), dbaas_exec_path)
 
         oci_exec_cur_stat = os.stat(oci_exec_path)
-        bmcs_exec_cur_stat = os.stat(bmcs_exec_path)
         dbaas_exec_cur_stat = os.stat(dbaas_exec_path)
         os.chmod(oci_exec_path, oci_exec_cur_stat.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-        os.chmod(bmcs_exec_path, bmcs_exec_cur_stat.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         os.chmod(dbaas_exec_path, dbaas_exec_cur_stat.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
         # find the site-packages directory in the virtual environment where we installed oci

--- a/services/container_engine/docs/inline-help/ce.txt
+++ b/services/container_engine/docs/inline-help/ce.txt
@@ -58,9 +58,10 @@ Options:
                                   which to create the cluster. [required]
   --kubernetes-version TEXT       The version of Kubernetes to install into the
                                   cluster masters. [required]
-  --kms-key-id TEXT               The OCID of the KMS Key to be used as the
-                                  master encryption key for Kubernetes Secret
-                                  encryption.
+  --kms-key-id TEXT               The OCID of the KMS key to be used as the
+                                  master encryption key for Kubernetes secret
+                                  encryption. When used, `kubernetesVersion`
+                                  must be at least `v1.13.0`.
   --wait-for-state [ACCEPTED|IN_PROGRESS|FAILED|SUCCEEDED|CANCELING|CANCELED]
                                   This operation asynchronously creates,
                                   modifies or deletes a resource and uses a work
@@ -474,33 +475,34 @@ Usage: oci ce cluster-options get [OPTIONS]
   Get options available for clusters.
 
 Options:
-  --cluster-option-id TEXT  The id of the option set to retrieve. Only "all" is
-                            supported. [required]
-  --from-json TEXT          Provide input to this command as a JSON document
-                            from a file using the file://path-to/file syntax.
-                            The --generate-full-command-json-input option can be
-                            used to generate a sample json file to be used with
-                            this command option. The key names are pre-populated
-                            and match the command option names (converted to
-                            camelCase format, e.g. compartment-id -->
-                            compartmentId), while the values of the keys need to
-                            be populated by the user before using the sample
-                            file as an input to this command. For any command
-                            option that accepts multiple values, the value of
-                            the key can be a JSON array.
-                            
-                            Options can still be
-                            provided on the command line. If an option exists in
-                            both the JSON document and the command line then the
-                            command line specified value will be used.
-                            
-                            For
-                            examples on usage of this option, please see our
-                            "using CLI with advanced JSON options" link: https:/
-                            /docs.cloud.oracle.com/iaas/Content/API/SDKDocs/cliu
-                            sing.htm#AdvancedJSONOptions
-  -?, -h, --help            For detailed help on any of these individual
-                            commands, enter <command> --help.
+  --cluster-option-id TEXT   The id of the option set to retrieve. Only "all" is
+                             supported. [required]
+  -c, --compartment-id TEXT  The OCID of the compartment.
+  --from-json TEXT           Provide input to this command as a JSON document
+                             from a file using the file://path-to/file syntax.
+                             The --generate-full-command-json-input option can
+                             be used to generate a sample json file to be used
+                             with this command option. The key names are pre-
+                             populated and match the command option names
+                             (converted to camelCase format, e.g. compartment-id
+                             --> compartmentId), while the values of the keys
+                             need to be populated by the user before using the
+                             sample file as an input to this command. For any
+                             command option that accepts multiple values, the
+                             value of the key can be a JSON array.
+                             
+                             Options can
+                             still be provided on the command line. If an option
+                             exists in both the JSON document and the command
+                             line then the command line specified value will be
+                             used.
+                             
+                             For examples on usage of this option, please
+                             see our "using CLI with advanced JSON options"
+                             link: https://docs.cloud.oracle.com/iaas/Content/AP
+                             I/SDKDocs/cliusing.htm#AdvancedJSONOptions
+  -?, -h, --help             For detailed help on any of these individual
+                             commands, enter <command> --help.
 
 ++++++++++++++++++++++++++++++++++++++++++++++
 $ oci ce node-pool --help
@@ -1005,6 +1007,7 @@ Options:
                               get all options, or use a cluster ID to get
                               options specific to the provided cluster.
                               [required]
+  -c, --compartment-id TEXT   The OCID of the compartment.
   --from-json TEXT            Provide input to this command as a JSON document
                               from a file using the file://path-to/file syntax.
                               The --generate-full-command-json-input option can

--- a/services/container_engine/src/oci_cli_container_engine/generated/containerengine_cli.py
+++ b/services/container_engine/src/oci_cli_container_engine/generated/containerengine_cli.py
@@ -79,7 +79,7 @@ ce_root_group.add_command(cluster_options_group)
 @cli_util.option('--compartment-id', required=True, help=u"""The OCID of the compartment in which to create the cluster.""")
 @cli_util.option('--vcn-id', required=True, help=u"""The OCID of the virtual cloud network (VCN) in which to create the cluster.""")
 @cli_util.option('--kubernetes-version', required=True, help=u"""The version of Kubernetes to install into the cluster masters.""")
-@cli_util.option('--kms-key-id', help=u"""The OCID of the KMS Key to be used as the master encryption key for Kubernetes Secret encryption.""")
+@cli_util.option('--kms-key-id', help=u"""The OCID of the KMS key to be used as the master encryption key for Kubernetes secret encryption. When used, `kubernetesVersion` must be at least `v1.13.0`.""")
 @cli_util.option('--options', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Optional attributes for the cluster.""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--wait-for-state', type=custom_types.CliCaseInsensitiveChoice(["ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED"]), multiple=True, help="""This operation asynchronously creates, modifies or deletes a resource and uses a work request to track the progress of the operation. Specify this option to perform the action and then wait until the work request reaches a certain state. Multiple states can be specified, returning on the first state. For example, --wait-for-state SUCCEEDED --wait-for-state FAILED would return on whichever lifecycle state is reached first. If timeout is reached, a return code of 2 is returned. For any other error, a return code of 1 is returned.""")
 @cli_util.option('--max-wait-seconds', type=click.INT, help="""The maximum time to wait for the work request to reach the state defined by --wait-for-state. Defaults to 1200 seconds.""")
@@ -429,17 +429,20 @@ def get_cluster(ctx, from_json, cluster_id):
 
 @cluster_options_group.command(name=cli_util.override('ce.get_cluster_options.command_name', 'get'), help=u"""Get options available for clusters.""")
 @cli_util.option('--cluster-option-id', required=True, help=u"""The id of the option set to retrieve. Only \"all\" is supported.""")
+@cli_util.option('--compartment-id', help=u"""The OCID of the compartment.""")
 @json_skeleton_utils.get_cli_json_input_option({})
 @cli_util.help_option
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={}, output_type={'module': 'container_engine', 'class': 'ClusterOptions'})
 @cli_util.wrap_exceptions
-def get_cluster_options(ctx, from_json, cluster_option_id):
+def get_cluster_options(ctx, from_json, cluster_option_id, compartment_id):
 
     if isinstance(cluster_option_id, six.string_types) and len(cluster_option_id.strip()) == 0:
         raise click.UsageError('Parameter --cluster-option-id cannot be whitespace or empty string')
 
     kwargs = {}
+    if compartment_id is not None:
+        kwargs['compartment_id'] = compartment_id
     kwargs['opc_request_id'] = cli_util.use_or_generate_request_id(ctx.obj['request_id'])
     client = cli_util.build_client('container_engine', ctx)
     result = client.get_cluster_options(
@@ -473,17 +476,20 @@ def get_node_pool(ctx, from_json, node_pool_id):
 
 @node_pool_options_group.command(name=cli_util.override('ce.get_node_pool_options.command_name', 'get'), help=u"""Get options available for node pools.""")
 @cli_util.option('--node-pool-option-id', required=True, help=u"""The id of the option set to retrieve. Use \"all\" get all options, or use a cluster ID to get options specific to the provided cluster.""")
+@cli_util.option('--compartment-id', help=u"""The OCID of the compartment.""")
 @json_skeleton_utils.get_cli_json_input_option({})
 @cli_util.help_option
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={}, output_type={'module': 'container_engine', 'class': 'NodePoolOptions'})
 @cli_util.wrap_exceptions
-def get_node_pool_options(ctx, from_json, node_pool_option_id):
+def get_node_pool_options(ctx, from_json, node_pool_option_id, compartment_id):
 
     if isinstance(node_pool_option_id, six.string_types) and len(node_pool_option_id.strip()) == 0:
         raise click.UsageError('Parameter --node-pool-option-id cannot be whitespace or empty string')
 
     kwargs = {}
+    if compartment_id is not None:
+        kwargs['compartment_id'] = compartment_id
     kwargs['opc_request_id'] = cli_util.use_or_generate_request_id(ctx.obj['request_id'])
     client = cli_util.build_client('container_engine', ctx)
     result = client.get_node_pool_options(

--- a/services/core/docs/inline-help/bv.txt
+++ b/services/core/docs/inline-help/bv.txt
@@ -709,6 +709,8 @@ Options:
   --kms-key-id TEXT               The OCID of the KMS key to be used as the
                                   master encryption key for the boot volume.
   --size-in-gbs INTEGER           The size of the volume in GBs.
+  --vpus-per-gb INTEGER           The number of Volume Performance Units that
+                                  will be applied to this boot volume per GB.
   --wait-for-state [PROVISIONING|RESTORING|AVAILABLE|TERMINATING|TERMINATED|FAULTY]
                                   This operation creates, modifies or deletes a
                                   resource that has a defined lifecycle state.
@@ -997,6 +999,8 @@ Options:
                                   passing it back in via the file:// syntax.
   --size-in-gbs INTEGER           The size to resize the volume to in GBs. Has
                                   to be larger than the current size.
+  --vpus-per-gb INTEGER           The number of Volume Performance Units that
+                                  will be applied to this boot volume per GB.
   --if-match TEXT                 For optimistic concurrency control. In the PUT
                                   or DELETE call for a resource, set the `if-
                                   match` parameter to the value of the etag from
@@ -1810,6 +1814,8 @@ Options:
                                   passing it back in via the file:// syntax.
   --kms-key-id TEXT               The OCID of the KMS key to be used as the
                                   master encryption key for the volume.
+  --vpus-per-gb INTEGER           The number of Volume Performance Units that
+                                  will be applied to this volume per GB.
   --size-in-gbs INTEGER           The size of the volume in GBs.
   --size-in-mbs INTEGER           [DEPRECATED] The size of the volume in MBs.
                                   The value must be a multiple of 1024. This
@@ -2120,6 +2126,8 @@ Options:
                                   in
                                   a file, modifying it as needed and then
                                   passing it back in via the file:// syntax.
+  --vpus-per-gb INTEGER           The number of Volume Performance Units that
+                                  will be applied to this volume per GB.
   --size-in-gbs INTEGER           The size to resize the volume to in GBs. Has
                                   to be larger than the current size.
   --if-match TEXT                 For optimistic concurrency control. In the PUT

--- a/services/core/src/oci_cli_blockstorage/generated/blockstorage_cli.py
+++ b/services/core/src/oci_cli_blockstorage/generated/blockstorage_cli.py
@@ -369,6 +369,7 @@ Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`""" + custom_types.cli_comp
 Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--kms-key-id', help=u"""The OCID of the KMS key to be used as the master encryption key for the boot volume.""")
 @cli_util.option('--size-in-gbs', type=click.INT, help=u"""The size of the volume in GBs.""")
+@cli_util.option('--vpus-per-gb', type=click.INT, help=u"""The number of Volume Performance Units that will be applied to this boot volume per GB.""")
 @cli_util.option('--wait-for-state', type=custom_types.CliCaseInsensitiveChoice(["PROVISIONING", "RESTORING", "AVAILABLE", "TERMINATING", "TERMINATED", "FAULTY"]), multiple=True, help="""This operation creates, modifies or deletes a resource that has a defined lifecycle state. Specify this option to perform the action and then wait until the resource reaches a given lifecycle state. Multiple states can be specified, returning on the first state. For example, --wait-for-state SUCCEEDED --wait-for-state FAILED would return on whichever lifecycle state is reached first. If timeout is reached, a return code of 2 is returned. For any other error, a return code of 1 is returned.""")
 @cli_util.option('--max-wait-seconds', type=click.INT, help="""The maximum time to wait for the resource to reach the lifecycle state defined by --wait-for-state. Defaults to 1200 seconds.""")
 @cli_util.option('--wait-interval-seconds', type=click.INT, help="""Check every --wait-interval-seconds to see whether the resource to see if it has reached the lifecycle state defined by --wait-for-state. Defaults to 30 seconds.""")
@@ -377,7 +378,7 @@ Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMP
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={'defined-tags': {'module': 'core', 'class': 'dict(str, dict(str, object))'}, 'freeform-tags': {'module': 'core', 'class': 'dict(str, string)'}, 'source-details': {'module': 'core', 'class': 'BootVolumeSourceDetails'}}, output_type={'module': 'core', 'class': 'BootVolume'})
 @cli_util.wrap_exceptions
-def create_boot_volume(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, availability_domain, compartment_id, source_details, backup_policy_id, defined_tags, display_name, freeform_tags, kms_key_id, size_in_gbs):
+def create_boot_volume(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, availability_domain, compartment_id, source_details, backup_policy_id, defined_tags, display_name, freeform_tags, kms_key_id, size_in_gbs, vpus_per_gb):
 
     kwargs = {}
 
@@ -403,6 +404,9 @@ def create_boot_volume(ctx, from_json, wait_for_state, max_wait_seconds, wait_in
 
     if size_in_gbs is not None:
         details['sizeInGBs'] = size_in_gbs
+
+    if vpus_per_gb is not None:
+        details['vpusPerGB'] = vpus_per_gb
 
     client = cli_util.build_client('blockstorage', ctx)
     result = client.create_boot_volume(
@@ -450,6 +454,7 @@ Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`""" + custom_types.cli_comp
 Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--kms-key-id', help=u"""The OCID of the KMS key to be used as the master encryption key for the boot volume.""")
 @cli_util.option('--size-in-gbs', type=click.INT, help=u"""The size of the volume in GBs.""")
+@cli_util.option('--vpus-per-gb', type=click.INT, help=u"""The number of Volume Performance Units that will be applied to this boot volume per GB.""")
 @cli_util.option('--wait-for-state', type=custom_types.CliCaseInsensitiveChoice(["PROVISIONING", "RESTORING", "AVAILABLE", "TERMINATING", "TERMINATED", "FAULTY"]), multiple=True, help="""This operation creates, modifies or deletes a resource that has a defined lifecycle state. Specify this option to perform the action and then wait until the resource reaches a given lifecycle state. Multiple states can be specified, returning on the first state. For example, --wait-for-state SUCCEEDED --wait-for-state FAILED would return on whichever lifecycle state is reached first. If timeout is reached, a return code of 2 is returned. For any other error, a return code of 1 is returned.""")
 @cli_util.option('--max-wait-seconds', type=click.INT, help="""The maximum time to wait for the resource to reach the lifecycle state defined by --wait-for-state. Defaults to 1200 seconds.""")
 @cli_util.option('--wait-interval-seconds', type=click.INT, help="""Check every --wait-interval-seconds to see whether the resource to see if it has reached the lifecycle state defined by --wait-for-state. Defaults to 30 seconds.""")
@@ -458,7 +463,7 @@ Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMP
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={'defined-tags': {'module': 'core', 'class': 'dict(str, dict(str, object))'}, 'freeform-tags': {'module': 'core', 'class': 'dict(str, string)'}}, output_type={'module': 'core', 'class': 'BootVolume'})
 @cli_util.wrap_exceptions
-def create_boot_volume_boot_volume_source_from_boot_volume_backup_details(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, availability_domain, compartment_id, source_details_id, backup_policy_id, defined_tags, display_name, freeform_tags, kms_key_id, size_in_gbs):
+def create_boot_volume_boot_volume_source_from_boot_volume_backup_details(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, availability_domain, compartment_id, source_details_id, backup_policy_id, defined_tags, display_name, freeform_tags, kms_key_id, size_in_gbs, vpus_per_gb):
 
     kwargs = {}
 
@@ -485,6 +490,9 @@ def create_boot_volume_boot_volume_source_from_boot_volume_backup_details(ctx, f
 
     if size_in_gbs is not None:
         details['sizeInGBs'] = size_in_gbs
+
+    if vpus_per_gb is not None:
+        details['vpusPerGB'] = vpus_per_gb
 
     details['sourceDetails']['type'] = 'bootVolumeBackup'
 
@@ -534,6 +542,7 @@ Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`""" + custom_types.cli_comp
 Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--kms-key-id', help=u"""The OCID of the KMS key to be used as the master encryption key for the boot volume.""")
 @cli_util.option('--size-in-gbs', type=click.INT, help=u"""The size of the volume in GBs.""")
+@cli_util.option('--vpus-per-gb', type=click.INT, help=u"""The number of Volume Performance Units that will be applied to this boot volume per GB.""")
 @cli_util.option('--wait-for-state', type=custom_types.CliCaseInsensitiveChoice(["PROVISIONING", "RESTORING", "AVAILABLE", "TERMINATING", "TERMINATED", "FAULTY"]), multiple=True, help="""This operation creates, modifies or deletes a resource that has a defined lifecycle state. Specify this option to perform the action and then wait until the resource reaches a given lifecycle state. Multiple states can be specified, returning on the first state. For example, --wait-for-state SUCCEEDED --wait-for-state FAILED would return on whichever lifecycle state is reached first. If timeout is reached, a return code of 2 is returned. For any other error, a return code of 1 is returned.""")
 @cli_util.option('--max-wait-seconds', type=click.INT, help="""The maximum time to wait for the resource to reach the lifecycle state defined by --wait-for-state. Defaults to 1200 seconds.""")
 @cli_util.option('--wait-interval-seconds', type=click.INT, help="""Check every --wait-interval-seconds to see whether the resource to see if it has reached the lifecycle state defined by --wait-for-state. Defaults to 30 seconds.""")
@@ -542,7 +551,7 @@ Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMP
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={'defined-tags': {'module': 'core', 'class': 'dict(str, dict(str, object))'}, 'freeform-tags': {'module': 'core', 'class': 'dict(str, string)'}}, output_type={'module': 'core', 'class': 'BootVolume'})
 @cli_util.wrap_exceptions
-def create_boot_volume_boot_volume_source_from_boot_volume_details(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, availability_domain, compartment_id, source_details_id, backup_policy_id, defined_tags, display_name, freeform_tags, kms_key_id, size_in_gbs):
+def create_boot_volume_boot_volume_source_from_boot_volume_details(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, availability_domain, compartment_id, source_details_id, backup_policy_id, defined_tags, display_name, freeform_tags, kms_key_id, size_in_gbs, vpus_per_gb):
 
     kwargs = {}
 
@@ -569,6 +578,9 @@ def create_boot_volume_boot_volume_source_from_boot_volume_details(ctx, from_jso
 
     if size_in_gbs is not None:
         details['sizeInGBs'] = size_in_gbs
+
+    if vpus_per_gb is not None:
+        details['vpusPerGB'] = vpus_per_gb
 
     details['sourceDetails']['type'] = 'bootVolume'
 
@@ -689,6 +701,7 @@ Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`""" + custom_types.cli_comp
 
 Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--kms-key-id', help=u"""The OCID of the KMS key to be used as the master encryption key for the volume.""")
+@cli_util.option('--vpus-per-gb', type=click.INT, help=u"""The number of Volume Performance Units that will be applied to this volume per GB.""")
 @cli_util.option('--size-in-gbs', type=click.INT, help=u"""The size of the volume in GBs.""")
 @cli_util.option('--size-in-mbs', type=click.INT, help=u"""The size of the volume in MBs. The value must be a multiple of 1024. This field is deprecated. Use sizeInGBs instead.""")
 @cli_util.option('--source-details', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Specifies the volume source details for a new Block volume. The volume source is either another Block volume in the same availability domain or a Block volume backup. This is an optional field. If not specified or set to null, the new Block volume will be empty. When specified, the new Block volume will contain data from the source volume or backup.""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
@@ -701,7 +714,7 @@ Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMP
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={'defined-tags': {'module': 'core', 'class': 'dict(str, dict(str, object))'}, 'freeform-tags': {'module': 'core', 'class': 'dict(str, string)'}, 'source-details': {'module': 'core', 'class': 'VolumeSourceDetails'}}, output_type={'module': 'core', 'class': 'Volume'})
 @cli_util.wrap_exceptions
-def create_volume(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, availability_domain, compartment_id, backup_policy_id, defined_tags, display_name, freeform_tags, kms_key_id, size_in_gbs, size_in_mbs, source_details, volume_backup_id):
+def create_volume(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, availability_domain, compartment_id, backup_policy_id, defined_tags, display_name, freeform_tags, kms_key_id, vpus_per_gb, size_in_gbs, size_in_mbs, source_details, volume_backup_id):
 
     kwargs = {}
 
@@ -723,6 +736,9 @@ def create_volume(ctx, from_json, wait_for_state, max_wait_seconds, wait_interva
 
     if kms_key_id is not None:
         details['kmsKeyId'] = kms_key_id
+
+    if vpus_per_gb is not None:
+        details['vpusPerGB'] = vpus_per_gb
 
     if size_in_gbs is not None:
         details['sizeInGBs'] = size_in_gbs
@@ -785,6 +801,7 @@ Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`""" + custom_types.cli_comp
 
 Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--kms-key-id', help=u"""The OCID of the KMS key to be used as the master encryption key for the volume.""")
+@cli_util.option('--vpus-per-gb', type=click.INT, help=u"""The number of Volume Performance Units that will be applied to this volume per GB.""")
 @cli_util.option('--size-in-gbs', type=click.INT, help=u"""The size of the volume in GBs.""")
 @cli_util.option('--size-in-mbs', type=click.INT, help=u"""The size of the volume in MBs. The value must be a multiple of 1024. This field is deprecated. Use sizeInGBs instead.""")
 @cli_util.option('--volume-backup-id', help=u"""The OCID of the volume backup from which the data should be restored on the newly created volume. This field is deprecated. Use the sourceDetails field instead to specify the backup for the volume.""")
@@ -796,7 +813,7 @@ Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMP
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={'defined-tags': {'module': 'core', 'class': 'dict(str, dict(str, object))'}, 'freeform-tags': {'module': 'core', 'class': 'dict(str, string)'}}, output_type={'module': 'core', 'class': 'Volume'})
 @cli_util.wrap_exceptions
-def create_volume_volume_source_from_volume_details(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, availability_domain, compartment_id, source_details_id, backup_policy_id, defined_tags, display_name, freeform_tags, kms_key_id, size_in_gbs, size_in_mbs, volume_backup_id):
+def create_volume_volume_source_from_volume_details(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, availability_domain, compartment_id, source_details_id, backup_policy_id, defined_tags, display_name, freeform_tags, kms_key_id, vpus_per_gb, size_in_gbs, size_in_mbs, volume_backup_id):
 
     kwargs = {}
 
@@ -820,6 +837,9 @@ def create_volume_volume_source_from_volume_details(ctx, from_json, wait_for_sta
 
     if kms_key_id is not None:
         details['kmsKeyId'] = kms_key_id
+
+    if vpus_per_gb is not None:
+        details['vpusPerGB'] = vpus_per_gb
 
     if size_in_gbs is not None:
         details['sizeInGBs'] = size_in_gbs
@@ -881,6 +901,7 @@ Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`""" + custom_types.cli_comp
 
 Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--kms-key-id', help=u"""The OCID of the KMS key to be used as the master encryption key for the volume.""")
+@cli_util.option('--vpus-per-gb', type=click.INT, help=u"""The number of Volume Performance Units that will be applied to this volume per GB.""")
 @cli_util.option('--size-in-gbs', type=click.INT, help=u"""The size of the volume in GBs.""")
 @cli_util.option('--size-in-mbs', type=click.INT, help=u"""The size of the volume in MBs. The value must be a multiple of 1024. This field is deprecated. Use sizeInGBs instead.""")
 @cli_util.option('--volume-backup-id', help=u"""The OCID of the volume backup from which the data should be restored on the newly created volume. This field is deprecated. Use the sourceDetails field instead to specify the backup for the volume.""")
@@ -892,7 +913,7 @@ Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMP
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={'defined-tags': {'module': 'core', 'class': 'dict(str, dict(str, object))'}, 'freeform-tags': {'module': 'core', 'class': 'dict(str, string)'}}, output_type={'module': 'core', 'class': 'Volume'})
 @cli_util.wrap_exceptions
-def create_volume_volume_source_from_volume_backup_details(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, availability_domain, compartment_id, source_details_id, backup_policy_id, defined_tags, display_name, freeform_tags, kms_key_id, size_in_gbs, size_in_mbs, volume_backup_id):
+def create_volume_volume_source_from_volume_backup_details(ctx, from_json, wait_for_state, max_wait_seconds, wait_interval_seconds, availability_domain, compartment_id, source_details_id, backup_policy_id, defined_tags, display_name, freeform_tags, kms_key_id, vpus_per_gb, size_in_gbs, size_in_mbs, volume_backup_id):
 
     kwargs = {}
 
@@ -916,6 +937,9 @@ def create_volume_volume_source_from_volume_backup_details(ctx, from_json, wait_
 
     if kms_key_id is not None:
         details['kmsKeyId'] = kms_key_id
+
+    if vpus_per_gb is not None:
+        details['vpusPerGB'] = vpus_per_gb
 
     if size_in_gbs is not None:
         details['sizeInGBs'] = size_in_gbs
@@ -2624,6 +2648,7 @@ Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`""" + custom_types.cli_comp
 
 Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
 @cli_util.option('--size-in-gbs', type=click.INT, help=u"""The size to resize the volume to in GBs. Has to be larger than the current size.""")
+@cli_util.option('--vpus-per-gb', type=click.INT, help=u"""The number of Volume Performance Units that will be applied to this boot volume per GB.""")
 @cli_util.option('--if-match', help=u"""For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource.  The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.""")
 @cli_util.option('--force', help="""Perform update without prompting for confirmation.""", is_flag=True)
 @cli_util.option('--wait-for-state', type=custom_types.CliCaseInsensitiveChoice(["PROVISIONING", "RESTORING", "AVAILABLE", "TERMINATING", "TERMINATED", "FAULTY"]), multiple=True, help="""This operation creates, modifies or deletes a resource that has a defined lifecycle state. Specify this option to perform the action and then wait until the resource reaches a given lifecycle state. Multiple states can be specified, returning on the first state. For example, --wait-for-state SUCCEEDED --wait-for-state FAILED would return on whichever lifecycle state is reached first. If timeout is reached, a return code of 2 is returned. For any other error, a return code of 1 is returned.""")
@@ -2634,7 +2659,7 @@ Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMP
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={'defined-tags': {'module': 'core', 'class': 'dict(str, dict(str, object))'}, 'freeform-tags': {'module': 'core', 'class': 'dict(str, string)'}}, output_type={'module': 'core', 'class': 'BootVolume'})
 @cli_util.wrap_exceptions
-def update_boot_volume(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_interval_seconds, boot_volume_id, defined_tags, display_name, freeform_tags, size_in_gbs, if_match):
+def update_boot_volume(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_interval_seconds, boot_volume_id, defined_tags, display_name, freeform_tags, size_in_gbs, vpus_per_gb, if_match):
 
     if isinstance(boot_volume_id, six.string_types) and len(boot_volume_id.strip()) == 0:
         raise click.UsageError('Parameter --boot-volume-id cannot be whitespace or empty string')
@@ -2660,6 +2685,9 @@ def update_boot_volume(ctx, from_json, force, wait_for_state, max_wait_seconds, 
 
     if size_in_gbs is not None:
         details['sizeInGBs'] = size_in_gbs
+
+    if vpus_per_gb is not None:
+        details['vpusPerGB'] = vpus_per_gb
 
     client = cli_util.build_client('blockstorage', ctx)
     result = client.update_boot_volume(
@@ -2807,6 +2835,7 @@ Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`""" + custom_types.cli_comp
 @cli_util.option('--freeform-tags', type=custom_types.CLI_COMPLEX_TYPE, help=u"""Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags].
 
 Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
+@cli_util.option('--vpus-per-gb', type=click.INT, help=u"""The number of Volume Performance Units that will be applied to this volume per GB.""")
 @cli_util.option('--size-in-gbs', type=click.INT, help=u"""The size to resize the volume to in GBs. Has to be larger than the current size.""")
 @cli_util.option('--if-match', help=u"""For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource.  The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.""")
 @cli_util.option('--force', help="""Perform update without prompting for confirmation.""", is_flag=True)
@@ -2818,7 +2847,7 @@ Example: `{\"Department\": \"Finance\"}`""" + custom_types.cli_complex_type.COMP
 @click.pass_context
 @json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={'defined-tags': {'module': 'core', 'class': 'dict(str, dict(str, object))'}, 'freeform-tags': {'module': 'core', 'class': 'dict(str, string)'}}, output_type={'module': 'core', 'class': 'Volume'})
 @cli_util.wrap_exceptions
-def update_volume(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_interval_seconds, volume_id, defined_tags, display_name, freeform_tags, size_in_gbs, if_match):
+def update_volume(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_interval_seconds, volume_id, defined_tags, display_name, freeform_tags, vpus_per_gb, size_in_gbs, if_match):
 
     if isinstance(volume_id, six.string_types) and len(volume_id.strip()) == 0:
         raise click.UsageError('Parameter --volume-id cannot be whitespace or empty string')
@@ -2841,6 +2870,9 @@ def update_volume(ctx, from_json, force, wait_for_state, max_wait_seconds, wait_
 
     if freeform_tags is not None:
         details['freeformTags'] = cli_util.parse_json_parameter("freeform_tags", freeform_tags)
+
+    if vpus_per_gb is not None:
+        details['vpusPerGB'] = vpus_per_gb
 
     if size_in_gbs is not None:
         details['sizeInGBs'] = size_in_gbs

--- a/services/database/docs/inline-help/db.txt
+++ b/services/database/docs/inline-help/db.txt
@@ -1574,6 +1574,7 @@ Commands:
   change-compartment  Move the Autonomous Database and its...
   create              Creates a new Autonomous Database.
   create-from-clone   Creates a new Autonomous Database.
+  data-safe           The Data Safe to use with this Autonomous...
   delete              Deletes the specified Autonomous Database.
   generate-wallet     Creates and downloads a wallet for the...
   get                 Gets the details of the specified Autonomous...
@@ -1941,6 +1942,96 @@ Options:
                                   s
   -?, -h, --help                  For detailed help on any of these individual
                                   commands, enter <command> --help.
+
+++++++++++++++++++++++++++++++++++++++++++++++
+$ oci db autonomous-database data-safe --help
+Usage: oci db autonomous-database data-safe [OPTIONS] COMMAND [ARGS]...
+
+  The Data Safe to use with this Autonomous Database.
+
+Options:
+  -?, -h, --help  For detailed help on any of these individual commands, enter
+                  <command> --help.
+
+Commands:
+  deregister  Asynchronously deregisters Data Safe for this...
+  register    Asynchronously registers Data Safe with this...
+
+++++++++++++++++++++++++++++++++++++++++++++++
+$ oci db autonomous-database data-safe deregister --help
+Usage: oci db autonomous-database data-safe deregister [OPTIONS]
+
+  Asynchronously deregisters Data Safe for this Autonomous Database.
+
+Options:
+  --autonomous-database-id TEXT  The database [OCID]. [required]
+  --from-json TEXT               Provide input to this command as a JSON
+                                 document from a file using the file://path-
+                                 to/file syntax.
+                                 
+                                 The --generate-full-command-
+                                 json-input option can be used to generate a
+                                 sample json file to be used with this command
+                                 option. The key names are pre-populated and
+                                 match the command option names (converted to
+                                 camelCase format, e.g. compartment-id -->
+                                 compartmentId), while the values of the keys
+                                 need to be populated by the user before using
+                                 the sample file as an input to this command.
+                                 For any command option that accepts multiple
+                                 values, the value of the key can be a JSON
+                                 array.
+                                 
+                                 Options can still be provided on the
+                                 command line. If an option exists in both the
+                                 JSON document and the command line then the
+                                 command line specified value will be used.
+                                 
+                                 For
+                                 examples on usage of this option, please see
+                                 our "using CLI with advanced JSON options"
+                                 link: https://docs.cloud.oracle.com/iaas/Conten
+                                 t/API/SDKDocs/cliusing.htm#AdvancedJSONOptions
+  -?, -h, --help                 For detailed help on any of these individual
+                                 commands, enter <command> --help.
+
+++++++++++++++++++++++++++++++++++++++++++++++
+$ oci db autonomous-database data-safe register --help
+Usage: oci db autonomous-database data-safe register [OPTIONS]
+
+  Asynchronously registers Data Safe with this Autonomous Database.
+
+Options:
+  --autonomous-database-id TEXT  The database [OCID]. [required]
+  --from-json TEXT               Provide input to this command as a JSON
+                                 document from a file using the file://path-
+                                 to/file syntax.
+                                 
+                                 The --generate-full-command-
+                                 json-input option can be used to generate a
+                                 sample json file to be used with this command
+                                 option. The key names are pre-populated and
+                                 match the command option names (converted to
+                                 camelCase format, e.g. compartment-id -->
+                                 compartmentId), while the values of the keys
+                                 need to be populated by the user before using
+                                 the sample file as an input to this command.
+                                 For any command option that accepts multiple
+                                 values, the value of the key can be a JSON
+                                 array.
+                                 
+                                 Options can still be provided on the
+                                 command line. If an option exists in both the
+                                 JSON document and the command line then the
+                                 command line specified value will be used.
+                                 
+                                 For
+                                 examples on usage of this option, please see
+                                 our "using CLI with advanced JSON options"
+                                 link: https://docs.cloud.oracle.com/iaas/Conten
+                                 t/API/SDKDocs/cliusing.htm#AdvancedJSONOptions
+  -?, -h, --help                 For detailed help on any of these individual
+                                 commands, enter <command> --help.
 
 ++++++++++++++++++++++++++++++++++++++++++++++
 $ oci db autonomous-database delete --help
@@ -5086,6 +5177,16 @@ Options:
                                   alphabetic character and can contain a maximum
                                   of eight alphanumeric characters. Special
                                   characters are not permitted. [required]
+  --db-unique-name TEXT           The database unique name. It must be greater
+                                  than 3 characters, but at most 30 characters,
+                                  begin with a letter, and contain only letters,
+                                  numbers, and underscores. The first eight
+                                  characters must also be unique within a
+                                  Database Domain and within a Database System
+                                  or VM Cluster. In addition, if it is not on a
+                                  VM Cluster it might either be identical to the
+                                  database name or prefixed by the datbase name
+                                  and followed by an underscore.
   --db-workload [OLTP|DSS]        Database workload type. Allowed values are:
                                   OLTP, DSS
   --ncharacter-set TEXT           National character set for the database. The
@@ -5183,6 +5284,16 @@ Options:
                                   alphabetic character and can contain a maximum
                                   of eight alphanumeric characters. Special
                                   characters are not permitted.
+  --db-unique-name TEXT           The database unique name. It must be greater
+                                  than 3 characters, but at most 30 characters,
+                                  begin with a letter, and contain only letters,
+                                  numbers, and underscores. The first eight
+                                  characters must also be unique within a
+                                  Database Domain and within a Database System
+                                  or VM Cluster. In addition, if it is not on a
+                                  VM Cluster it might either be identical to the
+                                  database name or prefixed by the datbase name
+                                  and followed by an underscore.
   --from-json TEXT                Provide input to this command as a JSON
                                   document from a file using the file://path-
                                   to/file syntax.
@@ -8114,6 +8225,16 @@ Options:
                                   alphabetic character and can contain a maximum
                                   of eight alphanumeric characters. Special
                                   characters are not permitted. [required]
+  --db-unique-name TEXT           The database unique name. It must be greater
+                                  than 3 characters, but at most 30 characters,
+                                  begin with a letter, and contain only letters,
+                                  numbers, and underscores. The first eight
+                                  characters must also be unique within a
+                                  Database Domain and within a Database System
+                                  or VM Cluster. In addition, if it is not on a
+                                  VM Cluster it might either be identical to the
+                                  database name or prefixed by the datbase name
+                                  and followed by an underscore.
   --db-version TEXT               A valid Oracle database version. To get a list
                                   of supported versions, use the command 'oci db
                                   version list'. [required]
@@ -8477,6 +8598,16 @@ Options:
                                   alphabetic character and can contain a maximum
                                   of eight alphanumeric characters. Special
                                   characters are not permitted.
+  --db-unique-name TEXT           The database unique name. It must be greater
+                                  than 3 characters, but at most 30 characters,
+                                  begin with a letter, and contain only letters,
+                                  numbers, and underscores. The first eight
+                                  characters must also be unique within a
+                                  Database Domain and within a Database System
+                                  or VM Cluster. In addition, if it is not on a
+                                  VM Cluster it might either be identical to the
+                                  database name or prefixed by the datbase name
+                                  and followed by an underscore.
   --ssh-authorized-keys-file FILENAME
                                   A file containing one or more public SSH keys
                                   to use for SSH access to the DB System. Use a

--- a/services/database/src/oci_cli_database/generated/database_cli.py
+++ b/services/database/src/oci_cli_database/generated/database_cli.py
@@ -2700,6 +2700,28 @@ def delete_vm_cluster_network(ctx, from_json, exadata_infrastructure_id, vm_clus
     cli_util.render_response(result, ctx)
 
 
+@autonomous_database_group.command(name=cli_util.override('db.deregister_autonomous_database_data_safe.command_name', 'deregister-autonomous-database-data-safe'), help=u"""Asynchronously deregisters Data Safe for this Autonomous Database.""")
+@cli_util.option('--autonomous-database-id', required=True, help=u"""The database [OCID].""")
+@json_skeleton_utils.get_cli_json_input_option({})
+@cli_util.help_option
+@click.pass_context
+@json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={})
+@cli_util.wrap_exceptions
+def deregister_autonomous_database_data_safe(ctx, from_json, autonomous_database_id):
+
+    if isinstance(autonomous_database_id, six.string_types) and len(autonomous_database_id.strip()) == 0:
+        raise click.UsageError('Parameter --autonomous-database-id cannot be whitespace or empty string')
+
+    kwargs = {}
+    kwargs['opc_request_id'] = cli_util.use_or_generate_request_id(ctx.obj['request_id'])
+    client = cli_util.build_client('database', ctx)
+    result = client.deregister_autonomous_database_data_safe(
+        autonomous_database_id=autonomous_database_id,
+        **kwargs
+    )
+    cli_util.render_response(result, ctx)
+
+
 @exadata_infrastructure_group.command(name=cli_util.override('db.download_exadata_infrastructure_config_file.command_name', 'download-exadata-infrastructure-config-file'), help=u"""Downloads the configuration file for the specified Exadata infrastructure.""")
 @cli_util.option('--exadata-infrastructure-id', required=True, help=u"""The Exadata infrastructure [OCID].""")
 @cli_util.option('--file', type=click.File(mode='wb'), required=True, help="The name of the file that will receive the response data, or '-' to write to STDOUT.")
@@ -5660,6 +5682,28 @@ def list_vm_clusters(ctx, from_json, all_pages, page_size, compartment_id, exada
             compartment_id=compartment_id,
             **kwargs
         )
+    cli_util.render_response(result, ctx)
+
+
+@autonomous_database_group.command(name=cli_util.override('db.register_autonomous_database_data_safe.command_name', 'register-autonomous-database-data-safe'), help=u"""Asynchronously registers Data Safe with this Autonomous Database.""")
+@cli_util.option('--autonomous-database-id', required=True, help=u"""The database [OCID].""")
+@json_skeleton_utils.get_cli_json_input_option({})
+@cli_util.help_option
+@click.pass_context
+@json_skeleton_utils.json_skeleton_generation_handler(input_params_to_complex_types={})
+@cli_util.wrap_exceptions
+def register_autonomous_database_data_safe(ctx, from_json, autonomous_database_id):
+
+    if isinstance(autonomous_database_id, six.string_types) and len(autonomous_database_id.strip()) == 0:
+        raise click.UsageError('Parameter --autonomous-database-id cannot be whitespace or empty string')
+
+    kwargs = {}
+    kwargs['opc_request_id'] = cli_util.use_or_generate_request_id(ctx.obj['request_id'])
+    client = cli_util.build_client('database', ctx)
+    result = client.register_autonomous_database_data_safe(
+        autonomous_database_id=autonomous_database_id,
+        **kwargs
+    )
     cli_util.render_response(result, ctx)
 
 

--- a/services/database/tests/unit/test_db_cli_extended.py
+++ b/services/database/tests/unit/test_db_cli_extended.py
@@ -34,3 +34,31 @@ class TestDBCliExtended(unittest.TestCase):
         result = util.invoke_command(['db', 'autonomous-database-wallet'])
         assert 'rotate-regional-wallet' in result.output
         assert 'update-autonomous-database-regional-wallet' not in result.output
+
+    def test_autonomous_database(self):
+        result = util.invoke_command(['db', 'autonomous-database'])
+        assert 'change-compartment' in result.output
+        assert 'create' in result.output
+        assert 'create-from-clone' in result.output
+        assert 'data-safe' in result.output
+        assert 'delete' in result.output
+        assert 'generate-wallet' in result.output
+        assert 'get' in result.output
+        assert 'list' in result.output
+        assert 'restore' in result.output
+        assert 'start' in result.output
+        assert 'stop' in result.output
+        assert 'update' in result.output
+        assert 'deregister-autonomous-database-data-safe' not in result.output
+        assert 'register-autonomous-database-data-safe' not in result.output
+
+    def test_autonomous_database_data_safe(self):
+        result = util.invoke_command(['db', 'autonomous-database', 'data-safe'])
+        assert 'register' in result.output
+        assert 'deregister' in result.output
+        result = util.invoke_command(['db', 'autonomous-database', 'data-safe', 'register'])
+        assert 'Error: Missing option(s)' in result.output
+        assert '--autonomous-database-id' in result.output
+        result = util.invoke_command(['db', 'autonomous-database', 'data-safe', 'deregister'])
+        assert 'Error: Missing option(s)' in result.output
+        assert '--autonomous-database-id' in result.output

--- a/services/load_balancer/examples_and_test_scripts/create_load_balancer.sh
+++ b/services/load_balancer/examples_and_test_scripts/create_load_balancer.sh
@@ -290,7 +290,7 @@ function create_lb_with_minimum_then_add_related_resources() {
     # We can create one or more rule sets to attach to the load balancer listener.
     oci lb rule-set create --load-balancer-id $LB_ID \
         --name ruleSetName\ 
-        --items '[{"action": "REMOVE_HTTP_REQUEST_HEADER","header": "AnyHeaderName3"},{"action": "ADD_HTTP_RESPONSE_HEADER","header": "AnyHeaderName4","value": "Any Value for Header"},{"action": "CONTROL_ACCESS_USING_HTTP_METHODS", "allowedMethods": ["PUT", "POST"], "statusCode": "403"}]'
+        --items '[{"action": "REMOVE_HTTP_REQUEST_HEADER","header": "AnyHeaderName3"},{"action": "ADD_HTTP_RESPONSE_HEADER","header": "AnyHeaderName4","value": "Any Value for Header"},{"action": "CONTROL_ACCESS_USING_HTTP_METHODS", "allowedMethods": ["PUT", "POST"], "statusCode": "403"},{"action": "REDIRECT","conditions": [{"attributeName": "PATH","attributeValue": "/original","operator": "EXACT_MATCH"}],"redirectUri": {"host": "example.com","path": "/example","port": 8090,"protocol": "http","query": "?lang=en"},"responseCode": 301}]'
 
     # Now that we have our certificates, backend set, path route set, and rule set we can add a listener. We need to specify a backend set which exists (e.g. the one we made)
     #

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open_relative("README.rst") as f:
     readme = f.read()
 
 requires = [
-    'oci==2.6.3',
+    'oci==2.6.4',
     'arrow==0.10.0',
     'certifi',
     'click==6.7',
@@ -84,7 +84,7 @@ setup(
     description='Oracle Cloud Infrastructure CLI',
     long_description=readme,
     entry_points={
-        'console_scripts': ["bmcs=oci_cli.cli:cli", "oci=oci_cli.cli:cli",
+        'console_scripts': ["oci=oci_cli.cli:cli",
                             "create_backup_from_onprem=oci_cli.scripts.database.dbaas:create_backup_from_onprem"]
     },
     install_requires=requires,

--- a/src/oci_cli/__init__.py
+++ b/src/oci_cli/__init__.py
@@ -68,6 +68,7 @@ from . import cli_exceptions  # noqa: F401,E402
 from . import json_skeleton_utils  # noqa: F401,E402
 from . import string_utils  # noqa: F401,E402
 from . import help_text_producer  # noqa: F401,E402
+from . import raw_request_cli  # noqa: F401,E402
 from oci import config  # noqa: F401,E402
 from .version import __version__  # noqa: F401,E402
 

--- a/src/oci_cli/bin/OciTabExpansion.ps1
+++ b/src/oci_cli/bin/OciTabExpansion.ps1
@@ -39,23 +39,23 @@ function OciTabExpansionInternal($lastBlock) {
 	$ociAliasPattern = GetOciAliasPattern 
 	
 	switch -regex ($lastBlock -replace "^$($ociAliasPattern) ","") {
-		# Handles [oci|bmcs] <top-level command>
+		# Handles [oci] <top-level command>
 		"^(?<cmd>\w+?)$" {
             $com = $matches['cmd']
 			$ociTopLevelCommands | Where-Object { $_ -like "$com*" }
 		}
 	
-		# Handles [oci|bmcs] <top-level command> <sub-command> <sub-command> ...
+		# Handles [oci] <top-level command> <sub-command> <sub-command> ...
         "^(?<cmd>$ociSubcommandKeys)\s+(?<op>\S*)$" {
             ociCmdOperations $ociSubcommands $matches['cmd'] $matches['op']
         }
 		
-		# Handles [oci|bmcs] <some level of commands> --<param>
+		# Handles [oci] <some level of commands> --<param>
         "^(?<cmd>$ociCommandsWithLongParams).* --(?<param>\S*)$" {
             expandOciLongParams $matches['cmd'] $matches['param']
         }
 
-        # Handles [oci|bmcs] <some level of commands> -<shortparam>
+        # Handles [oci] <some level of commands> -<shortparam>
         "^(?<cmd>$ociCommandsWithShortParams).* -(?<shortparam>\S*)$" {
             expandOciShortParams $matches['cmd'] $matches['shortparam']
         }
@@ -81,7 +81,7 @@ function script:expandOciShortParams($cmd, $filter) {
 }
 
 function GetOciAliasPattern() {
-	$ociAliases = @("oci", "bmcs") + @(Get-Alias | where { $_.Definition -eq "oci" } | select -Exp Name) + @(Get-Alias | where { $_.Definition -eq "bmcs" } | select -Exp Name)
+	$ociAliases = @("oci") + @(Get-Alias | where { $_.Definition -eq "oci" } | select -Exp Name)
 	$ociAliasPattern = "($($ociAliases -join '|'))"
 	
 	return $ociAliasPattern
@@ -126,7 +126,7 @@ function TabExpansion($line, $lastWord) {
 	$ociAliasPattern = GetOciAliasPattern
 	
 	switch -regex ($lastBlock) {
-        # Execute OCI/BMCS tab completion
+        # Execute OCI tab completion
         "^$($ociAliasPattern) (.*)" { OciTabExpansion $lastBlock }
 
         # Fall back on existing tab expansion

--- a/src/oci_cli/bin/oci_autocomplete.sh
+++ b/src/oci_cli/bin/oci_autocomplete.sh
@@ -1,13 +1,6 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-_bmcs_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _BMCS_COMPLETE=complete $1 ) )
-    return 0
-}
-
 _oci_completion() {
     COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
                    COMP_CWORD=$COMP_CWORD \
@@ -15,5 +8,4 @@ _oci_completion() {
     return 0
 }
 
-complete -F _bmcs_completion -o default bmcs;
 complete -F _oci_completion -o default oci;

--- a/src/oci_cli/cli.py
+++ b/src/oci_cli/cli.py
@@ -5,6 +5,7 @@ from .cli_root import cli
 from . import cli_session  # noqa: F401,E402
 from . import cli_setup  # noqa: F401
 from . import cli_setup_bootstrap  # noqa: F401
+from . import raw_request_cli  # noqa: F401
 
 if __name__ == '__main__':
     cli()

--- a/src/oci_cli/cli_root.py
+++ b/src/oci_cli/cli_root.py
@@ -32,7 +32,7 @@ from . import cli_constants
 # important security information.
 logging.basicConfig(level=logging.WARN)
 
-BMCS_DEPRECATION_NOTICE = """WARNING: Invoking the CLI using 'bmcs' is deprecated and will be removed in future versions, starting in March 2018. To avoid interruption at that time, please move to invoking the CLI using 'oci' instead."""
+PYTHON2_DEPRECATION_NOTICE = """WARNING: Python 2 support is ending on December 31, 2019. Future versions of OCI CLI after January 2020, will not be compatible with Python 2. To avoid interruption at that time, please install OCI CLI in a compatible Python 3 environment."""
 
 OCI_CLI_AUTH_CHOICES = [cli_constants.OCI_CLI_AUTH_API_KEY, cli_constants.OCI_CLI_AUTH_INSTANCE_PRINCIPAL, cli_constants.OCI_CLI_AUTH_SESSION_TOKEN, cli_constants.OCI_CLI_AUTH_INSTANCE_OBO_USER, cli_constants.OCI_CLI_AUTH_RESOURCE_PRINCIPAL]
 
@@ -246,8 +246,8 @@ When passed the name of an option which takes complex input, this will print out
 @click.option('-?', '-h', '--help', is_flag=True, help='For detailed help on the individual OCI CLI command, enter <command> --help.')
 @click.pass_context
 def cli(ctx, config_file, profile, defaults_file, request_id, region, endpoint, cert_bundle, output, query, raw_output, auth, generate_full_command_json_input, generate_param_json_input, no_retry, debug, help):
-    if ctx.command_path == 'bmcs':
-        click.echo(click.style(BMCS_DEPRECATION_NOTICE, fg='red'), file=sys.stderr)
+    if sys.version_info[0] < 3 and not os.environ.get("SUPPRESS_PYTHON2_WARNING"):
+        click.echo(click.style(PYTHON2_DEPRECATION_NOTICE, fg='red'), file=sys.stderr)
 
     # Show help in any case if there are no subcommands, or if the help option
     # is used but there are subcommands, then set a flag for user later.

--- a/src/oci_cli/cli_util.py
+++ b/src/oci_cli/cli_util.py
@@ -354,7 +354,7 @@ def set_request_session_properties_from_context(session, ctx, uses_ssl=True):
         # TODO: Update this once alternate certs are exposed in the SDK.
         session.verify = cert_bundle
 
-    if ctx.obj['proxy'] or ctx.obj.get('settings', {}).get('proxy'):
+    if ctx.obj.get('settings', {}).get('proxy'):
         # If the proxy is specified explicitly on the command line then use that, otherwise use
         # the one from the cli_rc_file
         proxy_to_use = ctx.obj['proxy']
@@ -1474,6 +1474,13 @@ def warn_if_token_present_in_profile_but_not_using_token_auth(ctx):
 
 def is_windows():
     return sys.platform == 'win32' or sys.platform == 'cygwin'
+
+
+def get_jmespath_expression_from_context(ctx):
+    if ctx.obj['query']:
+        search_path = resolve_jmespath_query(ctx, ctx.obj['query'])
+        return jmespath.compile(search_path)
+    return None
 
 
 def resolve_jmespath_query(ctx, query):

--- a/src/oci_cli/raw_request_cli.py
+++ b/src/oci_cli/raw_request_cli.py
@@ -1,0 +1,96 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import click
+import json
+import oci
+import six.moves
+
+from .cli_root import cli
+from . import cli_util
+from . import custom_types
+
+
+@cli.command('raw-request', help="""Makes a raw request against an OCI service based on a provided URI, HTTP method and payload. This operation currently only supports JSON payloads.
+This operation will output a JSON structure that looks like:
+
+\b
+    {
+        "data": <a JSON array or object containing the parsed response body>,
+        "headers": <a JSON object where each header is a key and the value is the header value>,
+        "status": <the HTTP status code and reason, e.g. '200 OK', '404 Not Found'>
+    }
+""", short_help="""Makes a raw request against an OCI service""")
+@cli_util.option('--target-uri', required=True, help="""The URI to make the request against""")
+@cli_util.option('--http-method', type=custom_types.CliCaseInsensitiveChoice(["DELETE", "GET", "HEAD", "POST", "PUT"]), required=True, help="""The HTTP method to use""")
+@cli_util.option('--request-body', type=custom_types.CLI_COMPLEX_TYPE, help="""Data to send in the body of the request. """ + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
+@cli_util.option('--request-headers', type=custom_types.CLI_COMPLEX_TYPE, help="""Additional headers to send as part of the request. """ + custom_types.cli_complex_type.COMPLEX_TYPE_HELP)
+@cli_util.help_option
+@click.pass_context
+@cli_util.wrap_exceptions
+def make_raw_request(ctx, target_uri, http_method, request_body, request_headers):
+    _make_raw_request(ctx, target_uri, http_method, request_body, request_headers)
+
+
+def _make_raw_request(ctx, target_uri, http_method, request_body, request_headers):
+    # Endpoint doesn't make sense because we're asking someone for a --target-uri. We could also just use the --endpoint parameter but that
+    # feels like an overloading of that concept (which is declared in cli_root)
+    if ctx.obj['endpoint']:
+        raise click.UsageError('The --endpoint parameter cannot be specified with this command')
+
+    # Table output may not make too much sense here because we're also dumping out headers and status code, in addition
+    # to the data
+    if ctx.obj['output'] == 'table':
+        raise click.UsageError('The table output format is not supported with this command')
+
+    if ctx.obj['debug']:
+        six.moves.http_client.HTTPConnection.debuglevel = 1
+
+    jmespath_expression = cli_util.get_jmespath_expression_from_context(ctx)
+
+    # Deliberately a bit open as we can permit an empty string through as an empty request body
+    parsed_request_body = ''
+    if request_body is not None and request_body.strip() != '':
+        request_body_as_dict = cli_util.parse_json_parameter('request_body', request_body)
+        parsed_request_body = json.dumps(request_body_as_dict)
+
+    additional_headers = {}
+    if request_headers:
+        additional_headers = cli_util.parse_json_parameter('request_headers', request_headers)
+
+    retry_strategy = oci.retry.DEFAULT_RETRY_STRATEGY
+    if ctx.obj['no_retry']:
+        retry_strategy = oci.retry.NoneRetryStrategy()
+
+    # Make a request and output the results. The retry strategy should make sure that we can ride out
+    # connection errors or timeouts, but its logic around ServiceError will not kick in because that's our
+    # construct and not something which requests raises.
+    #
+    # However, with the spirit of this operation I think that is OK because really we just want to make a
+    # call and then display the result (even if the result of that call is not a 2xx), so even a 4xx or 5xx
+    # would be considered successful from this operation's perspective as it was able to hit a URI and get
+    # a response
+    with cli_util.build_raw_requests_session(ctx) as requests_session:
+        response = retry_strategy.make_retrying_call(
+            requests_session.request,
+            method=http_method,
+            url=target_uri,
+            data=parsed_request_body,
+            headers=additional_headers
+        )
+
+        result_dict = {
+            'status': '{} {}'.format(response.status_code, response.reason),
+            'headers': {key: value for (key, value) in response.headers.items()}
+        }
+        try:
+            dict_from_response_body = response.json()
+            if jmespath_expression:
+                result_dict['data'] = jmespath_expression.search(dict_from_response_body)
+            else:
+                result_dict['data'] = dict_from_response_body
+        except ValueError:
+            # We may not have gotten valid JSON. In that case, do our best and just display something
+            result_dict['data'] = response.text
+
+        print(cli_util.pretty_print_format(result_dict))

--- a/src/oci_cli/version.py
+++ b/src/oci_cli/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = '2.6.11'
+__version__ = '2.6.12'

--- a/tests/test_json_skeleton_command_coverage.py
+++ b/tests/test_json_skeleton_command_coverage.py
@@ -27,6 +27,7 @@ IGNORED_COMMANDS = [
     ['session', 'refresh'],
     ['session', 'terminate'],
     ['session', 'validate'],
+    ['raw-request'],
     # Note this is being added b/c python sdk doesn't generate models
     # for top level enums.
     # This means that the --generate-full-command-json-input will not work

--- a/tests/util.py
+++ b/tests/util.py
@@ -410,7 +410,7 @@ def log_test(func):
 def collect_commands(command, prefix=None, leaf_commands_only=False):
     """Returns a list of commands under and including the given command.
         Each entry is a list of strings to invoke a particular command,
-        such as ["bmcs", "iam", "user", "list"]."""
+        such as ["oci", "iam", "user", "list"]."""
     for path, _, _ in _collect_commands(command, prefix, leaf_commands_only):
         yield path
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ markers =
 envlist = py27, py35
 
 [testenv]
-passenv = CLI_TESTS_ADMIN_PASS_PHRASE OCI_CLI* PYTHONHASHSEED RECORD_ONLY SKIP_BASIC_TESTS
+passenv = CLI_TESTS_ADMIN_PASS_PHRASE OCI_CLI* PYTHONHASHSEED RECORD_ONLY SKIP_BASIC_TESTS SUPPRESS_PYTHON2_WARNING
 deps = -r{toxinidir}/requirements.txt
 setenv =
     # Required so the oci script imports oci_cli from the venv


### PR DESCRIPTION
Added
* Support to register and deregister an autonomous data warehouse, or autonomous transaction processing, database with Data Safe.

  * ``oci db autonomous-database data-safe register --autonomous-database-id <autonomous database OCID>``
  * ``oci db autonomous-database data-safe deregister --autonomous-database-id <autonomous database OCID>`` 

* Add capability to redirect an input HTTP/HTTPS request URI to a different URI in Load Balancer service.

  * ``oci lb rule-set create --items``

* Console access to APEX and SQL Dev features for Create and Update ATP/ADW in the Database service

* Support for Volume Performance Units for Block Volumes in Block Storage service.

  * ``oci bv boot-volume create --vpus-per-gb``
  * ``oci bv boot-volume update --vpus-per-gb``

* Support for specifying compartment for OKE options APIs

  * ``oci ce cluster-options get --compartment-id``
  * ``oci ce node-pool-options get --compartment-id``

* Support for HTTP raw requests

  * ``oci raw-request``

* Deprecation warning message for python 2. This can be turned-off by setting the environment variable ``SUPPRESS_PYTHON2_WARNING``.

Changed
* Removed deprecated ``bmcs`` entry point for CLI. Now only ``oci`` is supported.  
