### PR TITLE
Update install.ps1

### DIFF
--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -176,7 +176,7 @@ function FindLatestPythonExecutableInRegistry {
 function DownloadFile($Uri, $OutFile) {
     # PowerShell V2 doesn't support Invoke-WebRequest so use WebClient
     # Use Invoke-WebRequest on versions that support it since it writes progress
-    if ($PsVersionTable.PsVersion.Major > 2) {
+    if ($PsVersionTable.PsVersion.Major -gt 2) {
         Invoke-WebRequest -Uri $Uri -OutFile $OutFile -UseBasicParsing
     }
     else {


### PR DESCRIPTION
`$PsVersionTable.PsVersion.Major > 2` in powershell does not mean to compare a value greater than 2. 
But it writes the $PsVersionTable.PsVersion.Major (which is `5` on my machine) into a new file named `2`