### PR TITLE
Fixing --limit option to dict response where there is entries whose value is not a list 

### DIFF
--- a/src/oci_cli/cli_util.py
+++ b/src/oci_cli/cli_util.py
@@ -1749,7 +1749,8 @@ def list_call_get_up_to_limit(list_func_ref, record_limit, page_size, **func_kwa
             wrapped_array_pagination = True
             for key in sorted(call_result.data.attribute_map.keys()):
                 aggregated_results_dict.setdefault(key.replace("_", "-"), []).append(getattr(call_result.data, key))
-                remaining_items_to_fetch -= len(getattr(call_result.data, key))
+                if isinstance(getattr(call_result.data, key), list):
+                    remaining_items_to_fetch -= len(getattr(call_result.data, key))
         else:
             aggregated_results.extend(call_result.data)
             remaining_items_to_fetch -= len(call_result.data)

--- a/src/oci_cli/cli_util.py
+++ b/src/oci_cli/cli_util.py
@@ -1748,8 +1748,8 @@ def list_call_get_up_to_limit(list_func_ref, record_limit, page_size, **func_kwa
         if not isinstance(call_result.data, list):
             wrapped_array_pagination = True
             for key in sorted(call_result.data.attribute_map.keys()):
-                aggregated_results_dict.setdefault(key.replace("_", "-"), []).append(getattr(call_result.data, key))
                 if isinstance(getattr(call_result.data, key), list):
+                    aggregated_results_dict.setdefault(key.replace("_", "-"), []).append(getattr(call_result.data, key))
                     remaining_items_to_fetch -= len(getattr(call_result.data, key))
         else:
             aggregated_results.extend(call_result.data)


### PR DESCRIPTION
Hi, currently, our code at https://github.com/oracle/oci-cli/blob/ce4b5876411959b3500610959f5e4314bcb5b029/src/oci_cli/cli_util.py#L1752  can only handle the response in format of list of lists correctly, if the list has entry which is not list, then there will be an error. Below is a response from listing repos under a compartment using Artifact/Registry service(https://docs.oracle.com/en-us/iaas/Content/Registry/Concepts/registryoverview.htm API here https://docs.oracle.com/en-us/iaas/api/#/en/registry/20160918/)

{
    "items": [
        {
            "id": "ocid1.containerrepo.oc1.phx.0.odx-registry.aaaaaaaa7rp7schudiwke7l3actnfopevrxfzqzsdv5phxropy2j2xgfn2ia",
            "compartmentId": "ocid1.compartment.oc1..aaaaaaaagcpr5om2k2e3gz6kl2ro5udayuvf3obbi3jdgnpowg72hizvzflq",
            "displayName": "dongtestrepo",
            "isPublic": false,
            "imageCount": 0,
            "layerCount": 0,
            "layersSizeInBytes": 0,
            "lifecycleState": "AVAILABLE",
            "timeCreated": "2021-03-31T21:53:47.128Z"
        },
        {
            "id": "ocid1.containerrepo.oc1.phx.0.odx-registry.aaaaaaaa32r7sobuekufm7arqujrqwg3bmwsiyv2wgszfhe5n3h3uf7m7pqq",
            "compartmentId": "ocid1.compartment.oc1..aaaaaaaagcpr5om2k2e3gz6kl2ro5udayuvf3obbi3jdgnpowg72hizvzflq",
            "displayName": "dongtestrepo1",
            "isPublic": false,
            "imageCount": 0,
            "layerCount": 0,
            "layersSizeInBytes": 0,
            "lifecycleState": "AVAILABLE",
            "timeCreated": "2021-03-31T21:54:02.676Z"
        }
    ],
    "remainingItemsCount": 0,
    "layersSizeInBytes": 0,
    "repositoryCount": 2,
    "imageCount": 0,
    "layerCount": 0
}

when we use the oci cli 
`
oci --config-file YOUR_CONFIG artifacts container repository list  --compartment-id YOUR_COMPARTMENTID  --limit 50 --debug 
` 
the following error will be returned:
`
 TypeError: object of type 'int' has no len()
`
To fix that I only add a check whether the element is a list or not before we decrease the current remaining item number

A related ticket from OCIR team could be found https://jira.oci.oraclecorp.com/browse/OCIR-2291 More detaild description could be found on slack https://dyn.slack.com/archives/C7HFH0VT4/p1617228360220900  and DEX Queue ticket https://jira.oci.oraclecorp.com/browse/DEX-11572

Signed-off-by: Dong Wang <dong.w.wang@oracle.com>