### PR TITLE
Fixing --all option to dict response where there is entries whose value is not a list

### DIFF
--- a/src/oci_cli/cli_util.py
+++ b/src/oci_cli/cli_util.py
@@ -1749,8 +1749,7 @@ def list_call_get_up_to_limit(list_func_ref, record_limit, page_size, **func_kwa
             wrapped_array_pagination = True
             for key in sorted(call_result.data.attribute_map.keys()):
                 aggregated_results_dict.setdefault(key.replace("_", "-"), []).append(getattr(call_result.data, key))
-                if isinstance(getattr(call_result.data, key), list):
-                    remaining_items_to_fetch -= len(getattr(call_result.data, key))
+                remaining_items_to_fetch -= len(getattr(call_result.data, key))
         else:
             aggregated_results.extend(call_result.data)
             remaining_items_to_fetch -= len(call_result.data)

--- a/src/oci_cli/cli_util.py
+++ b/src/oci_cli/cli_util.py
@@ -1749,7 +1749,8 @@ def list_call_get_up_to_limit(list_func_ref, record_limit, page_size, **func_kwa
             wrapped_array_pagination = True
             for key in sorted(call_result.data.attribute_map.keys()):
                 aggregated_results_dict.setdefault(key.replace("_", "-"), []).append(getattr(call_result.data, key))
-                remaining_items_to_fetch -= len(getattr(call_result.data, key))
+                if isinstance(getattr(call_result.data, key), list):
+                    remaining_items_to_fetch -= len(getattr(call_result.data, key))
         else:
             aggregated_results.extend(call_result.data)
             remaining_items_to_fetch -= len(call_result.data)

--- a/src/oci_cli/cli_util.py
+++ b/src/oci_cli/cli_util.py
@@ -1807,7 +1807,8 @@ def list_call_get_all_results(list_func_ref, ctx=None, is_json=False, stream_out
             if not isinstance(call_result.data, list):
                 wrapped_array_pagination = True
                 for key in sorted(call_result.data.attribute_map.keys()):
-                    aggregated_results_dict.setdefault(key.replace("_", "-"), []).append(getattr(call_result.data, key))
+                    if isinstance(getattr(call_result.data, key), list):
+                        aggregated_results_dict.setdefault(key.replace("_", "-"), []).append(getattr(call_result.data, key))
             else:
                 if stream_output:
                     previous_page_has_data = stream_page(is_json, page_index, call_result, ctx, previous_page_has_data)


### PR DESCRIPTION
This is familiar to the PR [393](https://github.com/oracle/oci-cli/pull/393)
our code at
https://github.com/oracle/oci-cli/blob/ce4b5876411959b3500610959f5e4314bcb5b029/src/oci_cli/cli_util.py#L1809)
will make create an empty list for every key , then add  those separate values to the list to make an aggregated list for that key, then it will be flattened at https://github.com/oracle/oci-cli/blob/ce4b5876411959b3500610959f5e4314bcb5b029/src/oci_cli/cli_util.py#L1833)  but this doesn't work when the value of a key is not a list. In this case line 1833 `list(chain.from_iterable(aggregated_results_dict[key])) ` will fail.  An example of such response can be like this:

{
"items": [
{
"id": "ocid1.containerrepo.oc1.phx.0.odx-registry.aaaaaaaa7rp7schudiwke7l3actnfopevrxfzqzsdv5phxropy2j2xgfn2ia",
"compartmentId": "ocid1.compartment.oc1..aaaaaaaagcpr5om2k2e3gz6kl2ro5udayuvf3obbi3jdgnpowg72hizvzflq",
"displayName": "dongtestrepo",
"isPublic": false,
"imageCount": 0,
"layerCount": 0,
"layersSizeInBytes": 0,
"lifecycleState": "AVAILABLE",
"timeCreated": "2021-03-31T21:53:47.128Z"
},
{
"id": "ocid1.containerrepo.oc1.phx.0.odx-registry.aaaaaaaa32r7sobuekufm7arqujrqwg3bmwsiyv2wgszfhe5n3h3uf7m7pqq",
"compartmentId": "ocid1.compartment.oc1..aaaaaaaagcpr5om2k2e3gz6kl2ro5udayuvf3obbi3jdgnpowg72hizvzflq",
"displayName": "dongtestrepo1",
"isPublic": false,
"imageCount": 0,
"layerCount": 0,
"layersSizeInBytes": 0,
"lifecycleState": "AVAILABLE",
"timeCreated": "2021-03-31T21:54:02.676Z"
}
],
"remainingItemsCount": 0,
"layersSizeInBytes": 0,
"repositoryCount": 2,
"imageCount": 0,
"layerCount": 0
}

when we use the oci cli
oci --config-file YOUR_CONFIG artifacts container repository list --compartment-id YOUR_COMPARTMENTID --all --debug
the following error will be returned:
**TypeError: 'int' object is not iterab**
To fix that I only add a check whether the value for the key is a list or not before we append it to the default aggregated list

A related ticket from OCIR team could be found https://jira.oci.oraclecorp.com/browse/OCIR-2294 More detaild description about a similar issue  could be found on slack https://dyn.slack.com/archives/C7HFH0VT4/p1617228360220900 and DEX Queue ticket https://jira.oci.oraclecorp.com/browse/DEX-11572

Signed-off-by: Dong Wang dong.w.wang@oracle.com