### PR TITLE
Fix broken OCA link, add pip install option to README

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,7 +5,7 @@ Contributing to the Oracle Cloud Infrastructure CLI
 *This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.*
 
 Pull requests can be made under
-`The Oracle Contributor Agreement <https://www.oracle.com/technetwork/community/oca-486395.html>`_ (OCA).
+`The Oracle Contributor Agreement <https://oca.opensource.oracle.com>`_ (OCA).
 
 For pull requests to be accepted, the bottom of
 your commit message must have the following line using your name and

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,12 @@ Windows
 
     powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.ps1'))"
 
+Cross-platform (Python 3.6+)
+----------------------------
+::
+
+    pip install oci-cli
+
 See the `installation guide`__ for detailed installation instructions, options and troubleshooting.
 
 __ https://docs.cloud.oracle.com/Content/API/SDKDocs/cliinstall.htm


### PR DESCRIPTION
1. 404ing link to Oracle Contributor Agreement updated to https://oca.opensource.oracle.com/
2. Those not wishing or unable to install the Homebrew package manager may install the oci-cli PyPI package directly using `pip` inside a Python 3.6+ environment. Appends this approach to the end of the installation methods section of the README.