### PR TITLE
README: Installing on Fedora

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,13 @@ Oracle Linux 7
 
     sudo yum install python36-oci-cli
 
+
+Fedora Linux
+------------
+::
+
+    sudo dnf install oci-cli
+
 Windows
 -------
 ::


### PR DESCRIPTION
There is now an `oci-cli` package in Fedora Linux that can be installed via `dnf install oci-cli` on Fedora 38 and later.

* https://src.fedoraproject.org/rpms/oci-cli