### PR TITLE
Add syntax highlighting to `README.md`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Mac OS X
 
 Linux
 -----
-::
+.. code-block:: bash
 
     bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh)"
 
@@ -76,7 +76,7 @@ Oracle Linux 7
 
 Windows
 -------
-::
+.. code-block:: powershell
 
     powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.ps1'))"
 


### PR DESCRIPTION
Note that [The Oracle Contributor Agreement](https://www.oracle.com/technetwork/community/oca-486395.html) in [`CONTRIBUTING.rst`](https://github.com/oracle/oci-cli/blob/50ff160440223189241c806156645309cd3cb493/CONTRIBUTING.rst?plain=1#L8) redirects to a  `Page not found` error.