### PR TITLE
chore: bump pyyaml to 6.0.2 to support py3.13 build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ vcrpy==4.2.1; python_version >= '3.10'
 virtualenv==20.13.0
 pytest-xdist==1.22.2
 pytest-forked==1.0.2
-PyYAML>=5.4,<=6.0.1
+PyYAML>=5.4,<=6.0.2
 docutils==0.15.2
 prompt-toolkit==3.0.29; python_version == '3.6'
 prompt-toolkit>=3.0.38,<=3.0.43; python_version > '3.6'

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ requires = [
     'six>=1.15.0',
     'terminaltables==3.1.10',
     'pyOpenSSL>=17.5.0,<25.0.0',
-    'PyYAML>=5.4,<=6.0.1',
+    'PyYAML>=5.4,<=6.0.2',
     'prompt-toolkit>=3.0.38,<=3.0.43; python_version > "3.6"',
     'prompt-toolkit==3.0.29; python_version == "3.6"'
 ]


### PR DESCRIPTION
see pyyaml 6.0.2 rel, https://github.com/yaml/pyyaml/releases/tag/6.0.2

relates to https://github.com/Homebrew/homebrew-core/pull/193481