### PR TITLE
remove trailing whitespaces in validate_label_private_key()

### DIFF
--- a/src/oci_cli/cli_root.py
+++ b/src/oci_cli/cli_root.py
@@ -581,6 +581,8 @@ def validate_label_private_key(file_path):
     with open(file_path, "r") as file:
         content = file.read()
 
+    # remove trailing whitespaces
+    content = content.rstrip()
     return content.endswith(PRIVATE_KEY_LABEL)
 
 


### PR DESCRIPTION
Fix: Add whitespace removal to `validate_label_private_key()` function using:
    
```
# remove trailing whitespaces
content = content.rstrip()
```

Without this check, at least on macos the `validate_label_private_key()` returns `False` even when the key file correctly ends with `PRIVATE_KEY_LABEL`. This is probably due to how macos handles line endings. After removing whitespaces, the function now returns `True`.

This should fix issue #905.