### PR TITLE
fix the incorrect import with prefix src

### DIFF
--- a/services/cims/src/oci_cli_incident/cims_cli_extended.py
+++ b/services/cims/src/oci_cli_incident/cims_cli_extended.py
@@ -12,8 +12,7 @@ from oci_cli import cli_util
 from services.cims.src.oci_cli_incident.generated.incident_cli import incident_group
 from oci_cli import custom_types
 from oci_cli import json_skeleton_utils
-
-from src.oci_cli import cli_exceptions
+from oci_cli import cli_exceptions
 
 # remove update-incident stand-alone command
 # incident_cli.incident_root_group.commands.pop(incident_cli.update_incident_group.name)


### PR DESCRIPTION
Fixes: #976

An import entry in `services/cims/src/oci_cli_incident/cims_cli_extended.py` was referring to the src/ directory, which will end up in import error, making `oci support` subcommands to fail.
```python
from oci_cli import custom_types
from oci_cli import json_skeleton_utils

from src.oci_cli import cli_exceptions
```

