### PR TITLE
fix: replace pkg_resources.load_entry_point for setuptools 82+

### DIFF
--- a/src/oci_cli/oci_template.py
+++ b/src/oci_cli/oci_template.py
@@ -4,7 +4,6 @@
 
 # EASY-INSTALL-ENTRY-SCRIPT: 'oci-cli','console_scripts','oci'
 # This is used be setup.py to create the oci command.
-__requires__ = 'oci-cli'
 import re
 import sys
 
@@ -13,21 +12,21 @@ import sys
 # setuptools.command.easy_install.ScriptWriter.
 
 # Loading a fips_libcrypto_file must be executed prior to
-# importing load_entry_point, otherwise overrides from libcrypto will not work.
+# importing the CLI entry point, otherwise overrides from libcrypto will not work.
 # It is normal that hashlib.md5 will be disabled from this change.
 
 # This will invoke __init__ which will configure fips by using
 # the environment variable, OCI_CLI_FIPS_LIBCRYPTO_FILE.
-# Note that we could import anything fromn oci_cli to invoke __init__.
+# Note that we could import anything from oci_cli to invoke __init__.
 # There is nothing special about this import.
 from oci_cli import fips  # noqa F401
 
 ####################################################################
 
-from pkg_resources import load_entry_point
+# Import the CLI directly instead of using pkg_resources.load_entry_point
+# which was removed in setuptools 82 (PEP 740, Feb 2026)
+from oci_cli import cli
 
 if __name__ == '__main__':
     sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
-    sys.exit(
-        load_entry_point('oci-cli', 'console_scripts', 'oci')()
-    )
+    sys.exit(cli())


### PR DESCRIPTION
## Summary

The  entry point script uses , which was removed in setuptools 82.0.0 (PEP 740, Feb 2026). This breaks the oci CLI when installed with the latest setuptools.

## Fix

Replace  with a direct import of the CLI function:

- Removed:  (pkg_resources-specific)
- Removed: 
- Removed: 
- Added: 
- Added: 

The FIPS configuration (libcrypto overrides) still runs first via the  import.

## Testing

pip install setuptools>=82
pip install oci-cli  # should work without pkg_resources error
oci --version

