### PR TITLE
fix: suggest true/false completions for BOOLEAN params in interactive mode

### DIFF
--- a/src/interactive/oci_shell_completer.py
+++ b/src/interactive/oci_shell_completer.py
@@ -5,6 +5,7 @@
 from prompt_toolkit.completion import Completer, Completion
 from alloy import alloy_util
 from interactive.oci_resources_completions import get_oci_resources
+import click
 import collections
 import shlex
 from interactive.utils import parameters_to_exclude, styles_dict
@@ -305,6 +306,12 @@ class OciShellCompleter(Completer):
                 remaing_sub_string,
             )
 
+        elif check_param_is_bool(command, parameter):
+            for value in ['true', 'false']:
+                completion = self.add_completion(remaing_sub_string, value, word_before_cursor)
+                if completion:
+                    completions.append(completion)
+
         else:
             if "OCI_OPS_CLI_TOOLS_IMPORT" not in os.environ:
                 completions = get_oci_resources(
@@ -344,6 +351,13 @@ def check_param_is_flag(command, param):
     for p in command.params:
         if param in p.opts:
             return p.is_flag
+    return False
+
+
+def check_param_is_bool(command, param):
+    for p in command.params:
+        if param in p.opts:
+            return isinstance(p.type, click.types.BoolParamType)
     return False
 
 


### PR DESCRIPTION
## Summary

Fixes #1056

In interactive mode (`oci -i`), BOOLEAN parameters had no completion
suggestions when pressing Tab. This caused an error in the bottom toolbar
because the completer fell through to the resource-fetching path, which
is incorrect for BOOLEAN types.

## Changes

- Added `check_param_is_bool()` helper in `oci_shell_completer.py`,
  following the same pattern as the existing `check_param_is_flag()`
- Added a `click.BOOL` branch in `get_completions()` that returns
  `true` and `false` as completions

## How to Validate

1. Start interactive mode: `oci -i`
2. Type and press Tab after a BOOLEAN parameter:
`oci iam compartment list --compartment-id-in-subtree <TAB>`
3. `true` and `false` now appear as suggestions



## Before
<img width="909" height="43" alt="image" src="https://github.com/user-attachments/assets/410a5a0f-6560-48a3-8733-19740fb83327" />


## After
<img width="789" height="93" alt="image" src="https://github.com/user-attachments/assets/2835c900-f877-497c-b615-cd7750172774" />

