### PR TITLE
use OCI_CLI_PROFILE for session authenticate profile name

### DIFF
--- a/src/oci_cli/cli_session.py
+++ b/src/oci_cli/cli_session.py
@@ -84,6 +84,9 @@ def authenticate(ctx, region, tenancy_name, profile_name, config_location, use_p
     if region is None:
         region = cli_setup.prompt_for_region()
 
+    if profile_name is None and cli_constants.OCI_CLI_PROFILE_ENV_VAR in os.environ:
+        profile_name = os.environ[cli_constants.OCI_CLI_PROFILE_ENV_VAR]
+
     # Validate profile name
     if profile_name:
         validate_profile_name(profile_name)


### PR DESCRIPTION
fixes #1091 

tests

```sh
$ python -m venv .venv
$ source .venv/bin/activate
$ pip install -e .
$ export OCI_CLI_PROFILE=oc1.ssh
$ python src/oci_cli/cli.py session authenticate --region us-ashburn-1
...
    Completed browser authentication process!
Config written to: /Users/ivang/.oci/config

    Try out your newly created session credentials with the following example command:

    oci iam region list --config-file /Users/ivang/.oci/config --profile oc1.ssh --auth security_token
```