### PR TITLE
make `create-kubeconfig` merge preserve some keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ tests/temp
 .cache/
 .project
 .wercker/
+.venv/

--- a/services/container_engine/src/oci_cli_container_engine/containerengine_cli_extended.py
+++ b/services/container_engine/src/oci_cli_container_engine/containerengine_cli_extended.py
@@ -731,6 +731,18 @@ def _merge_kubeconfig_yaml(dst_yaml, src_yaml, merge_key):
                 # It is either an update or repeat of an existing record so we need to update the existing record with
                 # new one
                 match = True
+                # we preserve some fields from the config cause the user might have set them for better dex
+                # this is a simple approach, if the list grows too big, consider another;
+                # like whitelisting on our side and only copying those
+                preserved_fields = {
+                    'contexts': ('context', ['namespace']),
+                    'clusters': ('cluster', ['proxy-url'])
+                }.get(merge_key)
+                if preserved_fields:
+                    section, fields = preserved_fields
+                    for field in fields:
+                        if field in j[section]:
+                            i[section][field] = j[section][field]
                 dst_yaml[merge_key][idx] = i
         if not match:
             # It is a new record so we need to add it to the list

--- a/services/container_engine/tests/unit/test_kubeconfig_merge.py
+++ b/services/container_engine/tests/unit/test_kubeconfig_merge.py
@@ -1,0 +1,48 @@
+# coding: utf-8
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+
+import unittest
+
+from services.container_engine.src.oci_cli_container_engine.containerengine_cli_extended import _merge_kubeconfig_yaml
+
+
+class TestKubeconfigMerge(unittest.TestCase):
+    def test_preserves_namespace_when_updating_context(self):
+        destination = {
+            'contexts': [{
+                'name': 'cluster',
+                'context': {'cluster': 'cluster', 'user': 'user', 'namespace': 'workloads'}
+            }]
+        }
+        source = {
+            'contexts': [{
+                'name': 'cluster',
+                'context': {'cluster': 'cluster', 'user': 'updated-user'}
+            }]
+        }
+
+        _merge_kubeconfig_yaml(destination, source, 'contexts')
+
+        assert destination['contexts'][0]['context'] == {
+            'cluster': 'cluster', 'user': 'updated-user', 'namespace': 'workloads'
+        }
+
+    def test_preserves_proxy_url_when_updating_cluster(self):
+        destination = {
+            'clusters': [{
+                'name': 'cluster',
+                'cluster': {'server': 'https://old.example', 'proxy-url': 'http://proxy.example'}
+            }]
+        }
+        source = {
+            'clusters': [{
+                'name': 'cluster',
+                'cluster': {'server': 'https://new.example'}
+            }]
+        }
+
+        _merge_kubeconfig_yaml(destination, source, 'clusters')
+
+        assert destination['clusters'][0]['cluster'] == {
+            'server': 'https://new.example', 'proxy-url': 'http://proxy.example'
+        }


### PR DESCRIPTION
this changes the behavior of `create-kubeconfig` merge to preserve `proxy-url` and `namespace` keys. these entries are convenient for DEX

closes https://github.com/oracle/oci-cli/issues/1102

## changes

- preserve `.contexts[].context.namespace` and `.clusters[].cluster.proxy-url` when merging
- add unit tests for this use case
- gitignore `.venv`

## validation

- ran 

```sh
$ OCI_CLI_CONFIG_FILE=test.conf .venv/bin/python -m pytest services/container_engine/tests/unit/test_kubeconfig_merge.py -v
================== test session starts ===================
platform darwin -- Python 3.11.15, pytest-7.1.2, pluggy-0.13.0 -- /Users/ivang/code/oci-cli/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/ivang/code/oci-cli, configfile: tox.ini
plugins: forked-1.0.2, xdist-1.22.2, cov-2.5.1
collected 2 items

services/container_engine/tests/unit/test_kubeconfig_merge.py::TestKubeconfigMerge::test_preserves_namespace_when_updating_context PASSED              [ 50%]
services/container_engine/tests/unit/test_kubeconfig_merge.py::TestKubeconfigMerge::test_preserves_proxy_url_when_updating_cluster PASSED              [100%]

=================== 2 passed in 0.01s ====================
```

```
# test.conf
[DEFAULT]
fingerprint=a:b:c
key_file=/tmp/somepath
tenancy=ocid1.tenancy.oc1..xyz
region=eu-zurich-1
security_token_file=/tmp/somepath
```

- ran `.venv/bin/python -m oci_cli.cli ce cluster create-kubeconfig --token-version 2.0.0 --kube-endpoint PRIVATE_ENDPOINT --cluster-id ocid1.cluster.oc1.eu-zurich-1.xyz --region eu-zurich-1`